### PR TITLE
DOCS-1302 add api redirect back

### DIFF
--- a/api-redirect.mdx
+++ b/api-redirect.mdx
@@ -68,6 +68,7 @@ function handleRedirect () {
   const uri = getRedirectPath() || "/api-reference";
 
   console.log("Redirecting to", uri);
+  window.location.href = uri;
 }
 
 handleRedirect();


### PR DESCRIPTION
The server does not have access to anything after `#` so we need to handle that client side. 

CF will route anything `/api/v2` to `/api-redirect`, the client handles the rest.