### PR TITLE
fix: formatting cleanup quickstart guides & get account endpoint

### DIFF
--- a/api-reference/endpoints/accounts/get-identityaccounts.mdx
+++ b/api-reference/endpoints/accounts/get-identityaccounts.mdx
@@ -1,3 +1,4 @@
 ---
+title: Get account
 openapi: get /identity/accounts/{id}
 ---

--- a/guides/payments/index.mdx
+++ b/guides/payments/index.mdx
@@ -5,6 +5,20 @@ description: Accept stablecoin pay-ins with real-time settlement. Issue on-chain
 
 import PaymentsConnectorTip from '/snippets/payments-connector-tip.mdx';
 
+## Get Started
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" href="/guides/payments/quickstart" icon="rocket">
+    Accept stablecoin pay-ins with real-time settlement. Issue on-chain refunds.
+  </Card>
+  <Card title="Payments Statuses" href="/guides/payments/status" icon="list-check">
+    Learn more about payment statuses.
+  </Card>
+  <Card title="Payments FAQ" href="/guides/payments/faq" icon="circle-question">
+    Get answers to common questions about payments.
+  </Card>
+</CardGroup>
+
 Use the Paxos APIs to effortlessly integrate stablecoin payment acceptance into your platform.
 Features include:
 
@@ -39,16 +53,3 @@ Most refund integrations follow a similar workflow for the Seller:
 1. [Send USD](/guides/payments/quickstart#refund-fund-account) to a designated refund account.
 1. [Initiate a crypto withdrawal](/guides/payments/quickstart#refund-initiate) to the Buyer's designated wallet address, using one of the [supported blockchains](/guides/payments/faq#supported-assets).
 1. Configure a [refund monitoring and reconciliation](/guides/payments/quickstart#refund-monitor-reconcile) request to confirm Pay-in transactions on the Paxos Platform.
-## Get Started
-
-<CardGroup cols={2}>
-  <Card title="Quickstart" href="/guides/payments/quickstart" icon="rocket">
-    Accept stablecoin pay-ins with real-time settlement. Issue on-chain refunds.
-  </Card>
-  <Card title="Payments Statuses" href="/guides/payments/status" icon="list-check">
-    Learn more about payment statuses.
-  </Card>
-  <Card title="Payments FAQ" href="/guides/payments/faq" icon="circle-question">
-    Get answers to common questions about payments.
-  </Card>
-</CardGroup>

--- a/guides/payments/quickstart.mdx
+++ b/guides/payments/quickstart.mdx
@@ -7,7 +7,6 @@ import PaymentsConnectorTip from '/snippets/payments-connector-tip.mdx';
 import BestPracticeRefId from '/snippets/best-practice-ref-id.mdx';
 import PaymentsPhantomWallet from '/snippets/payments-phantom-wallet.mdx';
 
-
 This guides walks you through the steps to set up a basic payments workflow using the Paxos Platform, including [configuring a stablecoin pay-in workflow](/guides/payments/quickstart#payment-workflow) and [setting up a refund workflow](/guides/payments/quickstart#refunds).
 Once completed, similar, more robust, workflows can be implemented in production.
 If you already have sandbox access, this guide should take less than one hour to complete.
@@ -17,7 +16,7 @@ If you already have sandbox access, this guide should take less than one hour to
 - Paxos may need to enable some API functionality described in the payments guides. Contact [Support](https://support.paxos.com) with any access issues.
 - If you need a developer sandbox account, [contact us](https://support.paxos.com/hc/en-us) before continuing.
 - The API endpoints require authentication with a **Client ID** and **Secret**.
-Each **Client ID** has a specific set of allowed scopes to access API endpoints.
+- Each **Client ID** has a specific set of allowed scopes to access API endpoints.
 
 <Accordion title="Example: Sandbox Credentials" id="generate-keys">
 

--- a/guides/payments/quickstart.mdx
+++ b/guides/payments/quickstart.mdx
@@ -124,7 +124,7 @@ curl --location 'https://api.sandbox.paxos.com/v2/transfer/deposit-addresses' \
 --header 'Accept: application/json' \
 --header 'Authorization: Bearer {access_token}' \
 --data '{
-    {/* highlight-start */}
+ 
     "profile_id": "eb1dbb95-8e22-471b-9ded-40bbfe309037",
     "crypto_network": "SOLANA",
     "ref_id": "da_73bcbb08-db06-4308-b0c2-2a6398012f8b",
@@ -196,7 +196,6 @@ The response confirms that a `total` of `7.06` PYUSD (`asset`) was converted to 
             "id": "9d93693f-5157-49f4-ae44-4a7a8eae3d73",
             "customer_id": "8cbc1177-d982-4750-a435-3c7f36245452",
             "profile_id": "eb1dbb95-8e22-471b-9ded-40bbfe309037",
-            {/* highlight-start */}
             "amount": "7.06",
             "total": "7.06",
             "fee": "0",


### PR DESCRIPTION
- Removed {/* highlight-end */}
- Updated title in api-reference/endpoints/accounts/get-identityaccounts.mdx to display “Get account” in sidebar
- Fixed indentation in guides/payments/quickstart.mdx