### PR TITLE
MESG-3550 Changelog for recipient_metadata on internal transfer

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -4,6 +4,10 @@ description: "Product updates and announcements"
 rss: true
 ---
 
+<Update label="July 25, 2025" description="v2 API">
+    **V2 API**: Adds optional `recipient_metadata` field to CreateInternalTransfer.
+</Update>
+
 <Update label="July 21, 2025" description="v2 API">
     **V2 API**: Adds ListAPICredentials endpoint. Lists all API credentials that have been created.
     **V2 API**: Add optional ids filter to ListProfiles to support filtering by specific profile IDs.


### PR DESCRIPTION
[Link to JIRA Ticket](https://itbitwiki.atlassian.net/browse/MESG-3550)

https://github.com/paxosglobal/pax/pull/43281 merged and deployed on Friday.

Adding changelog to tell customers about the new `recipient_metadata` field.