### PR TITLE
Simplify EDD guide introduction for clarity

### DIFF
--- a/guides/identity/edd.mdx
+++ b/guides/identity/edd.mdx
@@ -10,7 +10,7 @@ description: Manage the enhanced due diligence of an Identity on the Paxos Platf
 
 
 
-To ensure that Paxos meets regulatory requirements, when an identity is deemed high risk according to Paxos risk rating methodology, Paxos initiates a process called Enhanced Due Diligence (EDD).
+When an identity is deemed high risk, Paxos conducts Enhanced Due Diligence (EDD) to meet regulatory requirements.
 This can occur during onboarding, or during the lifecycle of an active identity (for example, if identity information changes that impacts risk rating; if suspicious transaction patterns occur on the account).
 When an identity enters the EDD process, Paxos requires the collection of documentary evidence supporting the initial KYC information provided.
 


### PR DESCRIPTION
## Summary
- Simplified the opening sentence of the EDD guide to be more concise and direct
- Changed from: "To ensure that Paxos meets regulatory requirements, when an identity is deemed high risk according to Paxos risk rating methodology, Paxos initiates a process called Enhanced Due Diligence (EDD)."
- Changed to: "When an identity is deemed high risk, Paxos conducts Enhanced Due Diligence (EDD) to meet regulatory requirements."

## Test plan
- [ ] Review the updated text in `guides/identity/edd.mdx`
- [ ] Confirm the sentence flows well with the rest of the document
- [ ] Verify the meaning remains clear and accurate

🤖 Generated with [Claude Code](https://claude.ai/code)