### PR TITLE
RP-4471 rename set_by to managed_by

### DIFF
--- a/api-reference/preview/paxos-v2-preview-identity-controls.openapi.json
+++ b/api-reference/preview/paxos-v2-preview-identity-controls.openapi.json
@@ -221,13 +221,13 @@
         ],
         "description": "The type of control applied to an identity.\n\n- `CLOSED`: Identity is closed and cannot perform any actions\n- `DORMANT`: Identity is dormant due to inactivity"
       },
-      "IdentityControlController": {
+      "IdentityControlManager": {
         "type": "string",
         "enum": [
           "PAXOS",
           "CLIENT"
         ],
-        "description": "Indicates who set the control.\n\n- `PAXOS`: Control was set by Paxos (e.g., for compliance or risk reasons)\n- `CLIENT`: Control was set by the client application"
+        "description": "Indicates who manages the control. The manager of a control may delete the control.\n\n- `PAXOS`: Control is managed by Paxos (e.g., for compliance or risk reasons) and cannot be deleted by the client.\n- `CLIENT`: Control is managed by the client and can be deleted by the client."
       },
       "ClientIdentityControlType": {
         "type": "string",
@@ -257,8 +257,8 @@
           "type": {
             "$ref": "#/components/schemas/IdentityControlType"
           },
-          "set_by": {
-            "$ref": "#/components/schemas/IdentityControlController"
+          "managed_by": {
+            "$ref": "#/components/schemas/IdentityControlManager"
           },
           "reason_code": {
             "$ref": "#/components/schemas/IdentityControlReasonCode"
@@ -304,7 +304,7 @@
           {
             "id": "59b8e3c5-2b6e-4fa6-afcf-8c685598241d",
             "type": "CLOSED",
-            "set_by": "CLIENT",
+            "managed_by": "CLIENT",
             "reason_code": "END_USER_REQUESTED",
             "reason": "User requested account closure",
             "created_at": "2006-01-02T15:04:05Z"
@@ -312,7 +312,7 @@
           {
             "id": "5f1eb60c-b292-482c-96fe-9e3e265abcd4",
             "type": "CLOSED",
-            "set_by": "PAXOS",
+            "managed_by": "PAXOS",
             "reason_code": "COMPLIANCE",
             "reason": "Account flagged for compliance review",
             "created_at": "2006-01-02T15:04:05Z"
@@ -320,7 +320,7 @@
           {
             "id": "ae54b3b4-cce6-4707-b34b-c9c4f0537798",
             "type": "DORMANT",
-            "set_by": "CLIENT",
+            "managed_by": "CLIENT",
             "reason_code": "DORMANT",
             "reason": "No activity for 180 days",
             "created_at": "2006-01-02T15:04:05Z",


### PR DESCRIPTION
follow-up on: https://github.com/paxosglobal/docs-mintlify/pull/99
context: https://itbit.slack.com/archives/C074DCQT1UH/p1759245659178859?thread_ts=1759245037.065239&cid=C074DCQT1UH
> set_by still has the issue of not actually describing what the field means, since paxos will in some cases set a control that can be unset by the client (which will be reflected by a value of CLIENT in this field)
if the stutter is an issue for readability, what about managed_by?