### PR TITLE
RP-5021: Add Mintlify preview for GetIdentity status_details

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1066,6 +1066,12 @@
             "pages": [
               "preview/overview"
             ]
+          },
+          {
+            "group": "Identity",
+            "pages": [
+              "preview/get-identity"
+            ]
           }
         ]
       },

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -1,0 +1,56 @@
+---
+openapi: get /v2/identity/identities/{id}
+---
+
+```bash OAuth Scope
+identity:read_identity
+```
+
+<Note>
+**Preview Feature**: The `status_details` object now includes `pending_requirements` and `failed_requirements` arrays. These fields provide structured insight into why an identity is `PENDING` or `DISABLED`.
+
+See [status_details](#status_details-object) for full field descriptions.
+</Note>
+
+## status_details Object
+
+The `status_details` object in the GetIdentity response now contains three fields:
+
+| Field | Description |
+|-------|-------------|
+| `active_controls` | Identity controls currently applied. See the [Identity Controls API](/api-reference/endpoints/identity-controls/overview). |
+| `pending_requirements` | Outstanding requirements blocking approval. |
+| `failed_requirements` | Requirements that have failed, blocking approval or causing disablement. |
+
+### pending_requirements
+
+Each entry in `pending_requirements` has a `type`, a human-readable `message`, and — for institution identities — an optional `member_list`.
+
+| Type | Description |
+|------|-------------|
+| `ID_VERIFICATION` | Identity verification (e.g., government ID) is pending. |
+| `DOCUMENT_VERIFICATION` | Document review is pending. |
+| `COMPLIANCE_CHECK` | Compliance screening or review is pending. |
+| `MEMBERS` | One or more institution members have outstanding requirements. Includes `member_list`. |
+
+### failed_requirements
+
+Each entry in `failed_requirements` has a `type`, a human-readable `message`, and — for institution identities — an optional `member_list`.
+
+| Type | Description |
+|------|-------------|
+| `ID_VERIFICATION` | Identity verification failed. |
+| `DOCUMENT_VERIFICATION` | Document verification failed. |
+| `COMPLIANCE_CHECK` | Compliance check failed. |
+| `MEMBERS` | One or more institution members have a failed status (disabled, denied, or error). Includes `member_list`. |
+
+### member_list
+
+Present on `MEMBERS` requirement types in both `pending_requirements` and `failed_requirements`. Each entry contains:
+
+| Field | Description |
+|-------|-------------|
+| `identity_id` | The identity ID of the member. |
+| `summary_status` | Current status of the member identity (e.g., `PENDING`, `DISABLED`, `DENIED`). |
+
+> Questions? Contact [Support](https://support.paxos.com).

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -28,7 +28,7 @@ Each entry in `requirements` has the following fields:
 | Field | Description |
 |-------|-------------|
 | `type` | The requirement type. See types below. |
-| `requirements_status` | `PENDING` — not yet fulfilled; may be under review or require user action. `FAILED` — requirement was not met; check `awaiting_action_from` to determine if action is needed. |
+| `requirement_status` | `PENDING` — not yet fulfilled; may be under review or require user action. `FAILED` — requirement was not met; check `awaiting_action_from` to determine if action is needed. |
 | `awaiting_action_from` | Who must act to resolve the requirement: `USER`, `PAXOS`, or `PARTNER`. Not present on `MEMBERS` type. **Coming soon.** |
 | `reason` | Human-readable description of the requirement status. |
 | `errors` | Specific error details for developer use only — do not expose `code` or `description` values directly to end users. Use `reason` for user-facing messaging. `code` will be a fixed enum of values. Not present on `MEMBERS` type. **Coming soon.** |

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -30,7 +30,9 @@ Each entry in `pending_requirements` has a `type`, a human-readable `message`, a
 |------|-------------|
 | `ID_VERIFICATION` | Identity verification (e.g., government ID) is pending. |
 | `DOCUMENT_VERIFICATION` | Document review is pending. |
-| `COMPLIANCE_CHECK` | Compliance screening or review is pending. |
+| `SCREENING_CHECK` | Sanctions or other screening check is pending. |
+| `COMPLIANCE_CHECK` | Compliance review is pending. |
+| `ENHANCED_DUE_DILIGENCE` | Enhanced due diligence review is pending. |
 | `MEMBERS` | One or more institution members have outstanding requirements. Includes `member_list`. |
 
 ### failed_requirements
@@ -44,6 +46,7 @@ Each entry in `failed_requirements` has a `type`, a human-readable `message`, an
 | `COMPLIANCE_CHECK` | Compliance check failed. |
 | `MEMBERS` | One or more institution members have a failed status (disabled, denied, or error). Includes `member_list`. |
 | `RISK_AWARENESS_ASSESSMENT` | Risk awareness assessment failed. |
+| `KYC_REFRESH` | KYC refresh is required. |
 
 ### member_list
 

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -32,7 +32,7 @@ Each entry in `requirements` has the following fields:
 | `awaiting_action_from` | Who must act to resolve the requirement: `USER`, `PAXOS`, or `PARTNER`. Not present on `MEMBERS` type. **Coming soon.** |
 | `reason` | Human-readable description of the requirement status. |
 | `errors` | Specific error details for developer use only — do not expose `code` or `description` values directly to end users. Use `reason` for user-facing messaging. `code` will be a fixed enum of values. Not present on `MEMBERS` type. **Coming soon.** |
-| `member_list` | For `MEMBERS` type only — list of members with their `identity_id` and `status`. |
+| `member_statuses` | For `MEMBERS` type only — list of members with their `identity_id` and `status`. |
 
 #### Requirement types
 
@@ -45,9 +45,9 @@ Each entry in `requirements` has the following fields:
 | `ENHANCED_DUE_DILIGENCE` | Institution | Enhanced due diligence review. |
 | `RISK_AWARENESS_ASSESSMENT` | Person | Risk awareness assessment. |
 | `KYC_REFRESH` | Person | Periodic re-verification of identity information. |
-| `MEMBERS` | Institution | One or more institution members have outstanding requirements. Includes `member_list`. |
+| `MEMBERS` | Institution | One or more institution members have outstanding requirements. Includes `member_statuses`. |
 
-### member_list
+### member_statuses (MEMBERS type only)
 
 Present on `MEMBERS` requirement types. Each entry contains:
 

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -28,7 +28,7 @@ Each entry in `requirements` has the following fields:
 | Field | Description |
 |-------|-------------|
 | `type` | The requirement type. See types below. |
-| `requirement_status` | `PENDING` — not yet fulfilled; may be under review or require client action. `FAILED` — requirement was not met; check `awaiting_action_from` to determine if action is needed. |
+| `status` | `PENDING` — not yet fulfilled; may be under review or require client action. `FAILED` — requirement was not met; check `awaiting_action_from` to determine if action is needed. |
 | `awaiting_action_from` | Who must act to resolve the requirement: `PAXOS` or `CLIENT`. Not present on `MEMBERS` type. |
 | `errors` | Specific error details for developer use only — do not expose `code` or `description` values directly to end users. `code` is a fixed enum of values; additional codes may be added in the future. |
 
@@ -43,7 +43,7 @@ Each entry in `requirements` has the following fields:
 | `ENHANCED_DUE_DILIGENCE` | Institution | Enhanced due diligence review. |
 | `RISK_AWARENESS_ASSESSMENT` | Person | Risk awareness assessment. |
 | `KYC_REFRESH` | Person | Periodic re-verification of identity information. |
-| `TIN_VERIFICATION` | Both | Tax identification number verification. |
+| `TAX_DETAILS_VERIFICATION` | Both | Tax identification number verification. |
 | `MEMBERS` | Institution only | One or more institution members have outstanding requirements. Check `institution_members` in the response for details on which members are failing or pending. |
 
 > Questions? Contact [Support](https://support.paxos.com).

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -7,53 +7,53 @@ identity:read_identity
 ```
 
 <Note>
-**Preview Feature**: The `status_details` object now includes `pending_requirements` and `failed_requirements` arrays. These fields provide structured insight into why an identity is `PENDING` or `DISABLED`.
+**Preview Feature**: The `status_details` object now includes a `requirements` array. This field provides structured insight into why an identity is `PENDING` or `DENIED`.
 
 See [status_details](#status_details-object) for full field descriptions.
 </Note>
 
 ## status_details Object
 
-The `status_details` object in the GetIdentity response now contains three fields:
+The `status_details` object in the GetIdentity response contains two fields:
 
 | Field | Description |
 |-------|-------------|
 | `active_controls` | Identity controls currently applied. See the [Identity Controls API](/api-reference/endpoints/identity-controls/overview). |
-| `pending_requirements` | Outstanding requirements blocking approval. |
-| `failed_requirements` | Requirements that have failed, blocking approval or causing disablement. |
+| `requirements` | All outstanding requirements for this identity, including both pending and failed entries. |
 
-### pending_requirements
+### requirements
 
-Each entry in `pending_requirements` has a `type`, a human-readable `message`, and — for institution identities — an optional `member_list`.
+Each entry in `requirements` has the following fields:
 
-| Type | Description |
-|------|-------------|
-| `ID_VERIFICATION` | Identity verification (e.g., government ID) is pending. |
-| `DOCUMENT_VERIFICATION` | Document review is pending. |
-| `SCREENING_CHECK` | Sanctions or other screening check is pending. |
-| `COMPLIANCE_CHECK` | Compliance review is pending. |
-| `ENHANCED_DUE_DILIGENCE` | Enhanced due diligence review is pending. |
-| `MEMBERS` | One or more institution members have outstanding requirements. Includes `member_list`. |
+| Field | Description |
+|-------|-------------|
+| `type` | The requirement type. See types below. |
+| `status` | `PENDING` — not yet fulfilled; may be under review or require user action. `FAILED` — requirement was not met; check `awaiting_action_from` to determine if action is needed. |
+| `awaiting_action_from` | Who must act to resolve the requirement: `USER`, `PAXOS`, or `PARTNER`. Not present on `MEMBERS` type. **Coming soon.** |
+| `reason` | Human-readable description of the requirement status. |
+| `errors` | Specific error details, each with a `code` and `description`. Not present on `MEMBERS` type. **Coming soon.** |
+| `member_list` | For `MEMBERS` type only — list of members with their `identity_id` and `summary_status`. |
 
-### failed_requirements
+#### Requirement types
 
-Each entry in `failed_requirements` has a `type`, a human-readable `message`, and — for institution identities — an optional `member_list`.
-
-| Type | Description |
-|------|-------------|
-| `ID_VERIFICATION` | Identity verification failed. |
-| `DOCUMENT_VERIFICATION` | Document verification failed. |
-| `COMPLIANCE_CHECK` | Compliance check failed. |
-| `MEMBERS` | One or more institution members have a failed status (disabled, denied, or error). Includes `member_list`. |
-| `KYC_REFRESH` | KYC refresh is required. |
+| Type | Applies to | Description |
+|------|-----------|-------------|
+| `ID_VERIFICATION` | Person | Government ID verification. |
+| `DOCUMENT_VERIFICATION` | Institution | Business document review. |
+| `SCREENING_CHECK` | Both | Sanctions or watchlist screening. |
+| `COMPLIANCE_CHECK` | Both | Internal compliance review. |
+| `ENHANCED_DUE_DILIGENCE` | Institution | Enhanced due diligence review. |
+| `RISK_AWARENESS_ASSESSMENT` | Person | Risk awareness assessment. |
+| `KYC_REFRESH` | Person | Periodic re-verification of identity information. |
+| `MEMBERS` | Institution | One or more institution members have outstanding requirements. Includes `member_list`. |
 
 ### member_list
 
-Present on `MEMBERS` requirement types in both `pending_requirements` and `failed_requirements`. Each entry contains:
+Present on `MEMBERS` requirement types. Each entry contains:
 
 | Field | Description |
 |-------|-------------|
 | `identity_id` | The identity ID of the member. |
-| `summary_status` | Current status of the member identity (e.g., `PENDING`, `DISABLED`, `DENIED`). |
+| `summary_status` | Current status of the member identity (e.g., `PENDING`, `DENIED`, `DISABLED`). |
 
 > Questions? Contact [Support](https://support.paxos.com).

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -45,7 +45,6 @@ Each entry in `failed_requirements` has a `type`, a human-readable `message`, an
 | `DOCUMENT_VERIFICATION` | Document verification failed. |
 | `COMPLIANCE_CHECK` | Compliance check failed. |
 | `MEMBERS` | One or more institution members have a failed status (disabled, denied, or error). Includes `member_list`. |
-| `RISK_AWARENESS_ASSESSMENT` | Risk awareness assessment failed. |
 | `KYC_REFRESH` | KYC refresh is required. |
 
 ### member_list

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -31,7 +31,7 @@ Each entry in `requirements` has the following fields:
 | `requirements_status` | `PENDING` — not yet fulfilled; may be under review or require user action. `FAILED` — requirement was not met; check `awaiting_action_from` to determine if action is needed. |
 | `awaiting_action_from` | Who must act to resolve the requirement: `USER`, `PAXOS`, or `PARTNER`. Not present on `MEMBERS` type. **Coming soon.** |
 | `reason` | Human-readable description of the requirement status. |
-| `errors` | Specific error details, each with a `code` and `description`. Not present on `MEMBERS` type. **Coming soon.** |
+| `errors` | Specific error details for developer use only — do not expose `code` or `description` values directly to end users. Use `reason` for user-facing messaging. `code` will be a fixed enum of values. Not present on `MEMBERS` type. **Coming soon.** |
 | `member_list` | For `MEMBERS` type only — list of members with their `identity_id` and `status`. |
 
 #### Requirement types

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -43,6 +43,7 @@ Each entry in `failed_requirements` has a `type`, a human-readable `message`, an
 | `DOCUMENT_VERIFICATION` | Document verification failed. |
 | `COMPLIANCE_CHECK` | Compliance check failed. |
 | `MEMBERS` | One or more institution members have a failed status (disabled, denied, or error). Includes `member_list`. |
+| `RISK_AWARENESS_ASSESSMENT` | Risk awareness assessment failed. |
 
 ### member_list
 

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -7,7 +7,7 @@ identity:read_identity
 ```
 
 <Note>
-**Preview Feature**: The `status_details` object now includes a `requirements` array. This field provides structured insight into why an identity is `PENDING` or `DENIED`.
+**Preview Feature**: The `status_details` object now includes a `requirements` array. This field provides structured insight into why an identity is `PENDING`, `DENIED`, or `DISABLED`.
 
 See [status_details](#status_details-object) for full field descriptions.
 </Note>
@@ -43,6 +43,7 @@ Each entry in `requirements` has the following fields:
 | `ENHANCED_DUE_DILIGENCE` | Institution | Enhanced due diligence review. |
 | `RISK_AWARENESS_ASSESSMENT` | Person | Risk awareness assessment. |
 | `KYC_REFRESH` | Person | Periodic re-verification of identity information. |
+| `TIN_VERIFICATION` | Both | Tax identification number verification. |
 | `MEMBERS` | Institution only | One or more institution members have outstanding requirements. Check `institution_members` in the response for details on which members are failing or pending. |
 
 > Questions? Contact [Support](https://support.paxos.com).

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -30,7 +30,7 @@ Each entry in `requirements` has the following fields:
 | `type` | The requirement type. See types below. |
 | `requirement_status` | `PENDING` — not yet fulfilled; may be under review or require user action. `FAILED` — requirement was not met; check `awaiting_action_from` to determine if action is needed. |
 | `awaiting_action_from` | Who must act to resolve the requirement: `USER`, `PAXOS`, or `PARTNER`. Not present on `MEMBERS` type. **Coming soon.** |
-| `reason` | Human-readable description of the requirement status. |
+| `reason` | Human-readable summary in the format `<Type> <status>` (e.g., `ID Verification failed`, `Screening Check pending`). Use this for user-facing messaging. |
 | `errors` | Specific error details for developer use only — do not expose `code` or `description` values directly to end users. Use `reason` for user-facing messaging. `code` will be a fixed enum of values. Not present on `MEMBERS` type. **Coming soon.** |
 | `member_statuses` | For `MEMBERS` type only — list of members with their `identity_id` and `status`. |
 

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -32,7 +32,7 @@ Each entry in `requirements` has the following fields:
 | `awaiting_action_from` | Who must act to resolve the requirement: `USER`, `PAXOS`, or `PARTNER`. Not present on `MEMBERS` type. **Coming soon.** |
 | `reason` | Human-readable description of the requirement status. |
 | `errors` | Specific error details, each with a `code` and `description`. Not present on `MEMBERS` type. **Coming soon.** |
-| `member_list` | For `MEMBERS` type only — list of members with their `identity_id` and `summary_status`. |
+| `member_list` | For `MEMBERS` type only — list of members with their `identity_id` and `status`. |
 
 #### Requirement types
 
@@ -54,6 +54,6 @@ Present on `MEMBERS` requirement types. Each entry contains:
 | Field | Description |
 |-------|-------------|
 | `identity_id` | The identity ID of the member. |
-| `summary_status` | Current status of the member identity (e.g., `PENDING`, `DENIED`, `DISABLED`). |
+| `status` | Current status of the member identity (e.g., `PENDING`, `DENIED`, `DISABLED`). |
 
 > Questions? Contact [Support](https://support.paxos.com).

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -28,7 +28,7 @@ Each entry in `requirements` has the following fields:
 | Field | Description |
 |-------|-------------|
 | `type` | The requirement type. See types below. |
-| `status` | `PENDING` — not yet fulfilled; may be under review or require user action. `FAILED` — requirement was not met; check `awaiting_action_from` to determine if action is needed. |
+| `requirements_status` | `PENDING` — not yet fulfilled; may be under review or require user action. `FAILED` — requirement was not met; check `awaiting_action_from` to determine if action is needed. |
 | `awaiting_action_from` | Who must act to resolve the requirement: `USER`, `PAXOS`, or `PARTNER`. Not present on `MEMBERS` type. **Coming soon.** |
 | `reason` | Human-readable description of the requirement status. |
 | `errors` | Specific error details, each with a `code` and `description`. Not present on `MEMBERS` type. **Coming soon.** |

--- a/preview/get-identity.mdx
+++ b/preview/get-identity.mdx
@@ -28,11 +28,9 @@ Each entry in `requirements` has the following fields:
 | Field | Description |
 |-------|-------------|
 | `type` | The requirement type. See types below. |
-| `requirement_status` | `PENDING` — not yet fulfilled; may be under review or require user action. `FAILED` — requirement was not met; check `awaiting_action_from` to determine if action is needed. |
-| `awaiting_action_from` | Who must act to resolve the requirement: `USER`, `PAXOS`, or `PARTNER`. Not present on `MEMBERS` type. **Coming soon.** |
-| `reason` | Human-readable summary in the format `<Type> <status>` (e.g., `ID Verification failed`, `Screening Check pending`). Use this for user-facing messaging. |
-| `errors` | Specific error details for developer use only — do not expose `code` or `description` values directly to end users. Use `reason` for user-facing messaging. `code` will be a fixed enum of values. Not present on `MEMBERS` type. **Coming soon.** |
-| `member_statuses` | For `MEMBERS` type only — list of members with their `identity_id` and `status`. |
+| `requirement_status` | `PENDING` — not yet fulfilled; may be under review or require client action. `FAILED` — requirement was not met; check `awaiting_action_from` to determine if action is needed. |
+| `awaiting_action_from` | Who must act to resolve the requirement: `PAXOS` or `CLIENT`. Not present on `MEMBERS` type. |
+| `errors` | Specific error details for developer use only — do not expose `code` or `description` values directly to end users. `code` is a fixed enum of values; additional codes may be added in the future. |
 
 #### Requirement types
 
@@ -40,20 +38,11 @@ Each entry in `requirements` has the following fields:
 |------|-----------|-------------|
 | `ID_VERIFICATION` | Person | Government ID verification. |
 | `DOCUMENT_VERIFICATION` | Institution | Business document review. |
-| `SCREENING_CHECK` | Both | Sanctions or watchlist screening. |
+| `SCREENING_CHECK` | Both | Background screening check. |
 | `COMPLIANCE_CHECK` | Both | Internal compliance review. |
 | `ENHANCED_DUE_DILIGENCE` | Institution | Enhanced due diligence review. |
 | `RISK_AWARENESS_ASSESSMENT` | Person | Risk awareness assessment. |
 | `KYC_REFRESH` | Person | Periodic re-verification of identity information. |
-| `MEMBERS` | Institution | One or more institution members have outstanding requirements. Includes `member_statuses`. |
-
-### member_statuses (MEMBERS type only)
-
-Present on `MEMBERS` requirement types. Each entry contains:
-
-| Field | Description |
-|-------|-------------|
-| `identity_id` | The identity ID of the member. |
-| `status` | Current status of the member identity (e.g., `PENDING`, `DENIED`, `DISABLED`). |
+| `MEMBERS` | Institution only | One or more institution members have outstanding requirements. Check `institution_members` in the response for details on which members are failing or pending. |
 
 > Questions? Contact [Support](https://support.paxos.com).

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -77,10 +77,6 @@
                         ],
                         "failed_requirements": [
                           {
-                            "type": "RISK_AWARENESS_ASSESSMENT",
-                            "message": "Failed PTE Risk Awareness Assessment"
-                          },
-                          {
                             "type": "KYC_REFRESH",
                             "message": "KYC refresh required"
                           }
@@ -596,10 +592,9 @@
           "DOCUMENT_VERIFICATION",
           "COMPLIANCE_CHECK",
           "MEMBERS",
-          "RISK_AWARENESS_ASSESSMENT",
           "KYC_REFRESH"
         ],
-        "description": "The type of failed requirement.\n\n- `ID_VERIFICATION`: Identity verification failed\n- `DOCUMENT_VERIFICATION`: Document verification failed\n- `COMPLIANCE_CHECK`: Compliance check failed\n- `MEMBERS`: One or more institution members have a failed status (e.g., disabled, denied, or error)\n- `RISK_AWARENESS_ASSESSMENT`: Risk awareness assessment failed\n- `KYC_REFRESH`: KYC refresh is required"
+        "description": "The type of failed requirement.\n\n- `ID_VERIFICATION`: Identity verification failed\n- `DOCUMENT_VERIFICATION`: Document verification failed\n- `COMPLIANCE_CHECK`: Compliance check failed\n- `MEMBERS`: One or more institution members have a failed status (e.g., disabled, denied, or error)\n- `KYC_REFRESH`: KYC refresh is required"
       },
       "MemberStatus": {
         "type": "object",

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -237,7 +237,7 @@
                             "type": "MEMBERS",
                             "requirements_status": "FAILED",
                             "reason": "One or more members could not be verified.",
-                            "member_list": [
+                            "member_statuses": [
                               {
                                 "identity_id": "b8e1f234-0011-4abc-9900-aabbccddeeff",
                                 "status": "DENIED"
@@ -620,7 +620,7 @@
               "$ref": "#/components/schemas/RequirementError"
             }
           },
-          "member_list": {
+          "member_statuses": {
             "type": "array",
             "description": "For institution identities, the list of members with their current status. Only present when `type` is `MEMBERS`.",
             "items": {

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -75,7 +75,7 @@
                         "requirements": [
                           {
                             "type": "ID_VERIFICATION",
-                            "status": "FAILED",
+                            "requirements_status": "FAILED",
                             "awaiting_action_from": "USER",
                             "reason": "Your information could not be verified.",
                             "errors": [
@@ -87,7 +87,7 @@
                           },
                           {
                             "type": "SCREENING_CHECK",
-                            "status": "PENDING",
+                            "requirements_status": "PENDING",
                             "awaiting_action_from": "PAXOS",
                             "reason": "Your information is under review.",
                             "errors": [
@@ -99,7 +99,7 @@
                           },
                           {
                             "type": "COMPLIANCE_CHECK",
-                            "status": "PENDING",
+                            "requirements_status": "PENDING",
                             "awaiting_action_from": "PAXOS",
                             "reason": "Your account is under review.",
                             "errors": [
@@ -111,7 +111,7 @@
                           },
                           {
                             "type": "RISK_AWARENESS_ASSESSMENT",
-                            "status": "FAILED",
+                            "requirements_status": "FAILED",
                             "awaiting_action_from": "USER",
                             "reason": "Risk awareness assessment is required.",
                             "errors": [
@@ -123,7 +123,7 @@
                           },
                           {
                             "type": "KYC_REFRESH",
-                            "status": "FAILED",
+                            "requirements_status": "FAILED",
                             "awaiting_action_from": "USER",
                             "reason": "Identity re-verification is required.",
                             "errors": [
@@ -195,7 +195,7 @@
                         "requirements": [
                           {
                             "type": "DOCUMENT_VERIFICATION",
-                            "status": "FAILED",
+                            "requirements_status": "FAILED",
                             "awaiting_action_from": "USER",
                             "reason": "Document verification could not be completed.",
                             "errors": [
@@ -211,7 +211,7 @@
                           },
                           {
                             "type": "SCREENING_CHECK",
-                            "status": "PENDING",
+                            "requirements_status": "PENDING",
                             "awaiting_action_from": "PARTNER",
                             "reason": "Your information is under review.",
                             "errors": [
@@ -223,7 +223,7 @@
                           },
                           {
                             "type": "COMPLIANCE_CHECK",
-                            "status": "PENDING",
+                            "requirements_status": "PENDING",
                             "awaiting_action_from": "PAXOS",
                             "reason": "Your account is under review.",
                             "errors": [
@@ -235,7 +235,7 @@
                           },
                           {
                             "type": "MEMBERS",
-                            "status": "FAILED",
+                            "requirements_status": "FAILED",
                             "reason": "One or more members could not be verified.",
                             "member_list": [
                               {
@@ -250,7 +250,7 @@
                           },
                           {
                             "type": "ENHANCED_DUE_DILIGENCE",
-                            "status": "PENDING",
+                            "requirements_status": "PENDING",
                             "awaiting_action_from": "USER",
                             "reason": "Additional information is required.",
                             "errors": [
@@ -324,7 +324,9 @@
             "example": { "customer_ref": "acme-corp-001" }
           },
           "summary_status": {
-            "$ref": "#/components/schemas/IdentitySummaryStatus"
+            "allOf": [{ "$ref": "#/components/schemas/IdentitySummaryStatus" }],
+            "description": "Deprecated. Use `status` instead. The overall onboarding and compliance status of the identity. `status` and `summary_status` return the same values.",
+            "deprecated": true
           },
           "status": {
             "type": "string",
@@ -549,7 +551,8 @@
           },
           "summary_status": {
             "type": "string",
-            "description": "The summary status of the member's identity.",
+            "description": "Deprecated. Use `status` instead. The status of the member's identity. `status` and `summary_status` return the same values.",
+            "deprecated": true,
             "example": "DENIED"
           }
         }
@@ -593,12 +596,12 @@
       "Requirement": {
         "type": "object",
         "description": "A requirement associated with the identity's onboarding or compliance review. Requirements with `status: FAILED` indicate an action is needed; requirements with `status: PENDING` are under review.",
-        "required": ["type", "status"],
+        "required": ["type", "requirements_status"],
         "properties": {
           "type": {
             "$ref": "#/components/schemas/RequirementType"
           },
-          "status": {
+          "requirements_status": {
             "$ref": "#/components/schemas/RequirementStatus"
           },
           "awaiting_action_from": {

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -42,13 +42,13 @@
                 },
                 "examples": {
                   "person_pending": {
-                    "summary": "Person identity pending with failed and pending requirements",
+                    "summary": "Person identity disabled due to expired KYC refresh",
                     "value": {
                       "id": "f190b163-208f-4d73-8deb-4fb8b24add00",
                       "type": "PERSON",
                       "ref_id": "user-abc-123",
-                      "status": "PENDING",
-                      "summary_status": "PENDING",
+                      "status": "DISABLED",
+                      "summary_status": "DISABLED",
                       "user_disabled": false,
                       "admin_disabled": false,
                       "created_at": "2026-04-01T10:00:00Z",
@@ -57,33 +57,22 @@
                         "first_name": "Jane",
                         "last_name": "Smith",
                         "date_of_birth": "1990-05-15",
-                        "id_verification_status": "DENIED",
+                        "id_verification_status": "APPROVED",
                         "sanctions_verification_status": "PENDING"
                       },
                       "status_details": {
                         "active_controls": [
                           {
                             "id": "ctrl-001",
-                            "type": "FROZEN",
+                            "type": "SELL_ONLY",
                             "set_by": "SET_BY_PAXOS",
                             "is_overridable": false,
                             "reason_code": "COMPLIANCE_KYC",
-                            "reason": "Account frozen pending identity re-verification.",
+                            "reason": "KYC refresh expired",
                             "created_at": "2026-04-10T08:00:00Z"
                           }
                         ],
                         "requirements": [
-                          {
-                            "type": "ID_VERIFICATION",
-                            "requirement_status": "FAILED",
-                            "awaiting_action_from": "PAXOS",
-                            "errors": [
-                              {
-                                "code": "identity_verification_failed",
-                                "description": "Identity verification could not be completed."
-                              }
-                            ]
-                          },
                           {
                             "type": "SCREENING_CHECK",
                             "requirement_status": "PENDING",
@@ -92,17 +81,6 @@
                               {
                                 "code": "screening_in_progress",
                                 "description": "Screening verification is in progress."
-                              }
-                            ]
-                          },
-                          {
-                            "type": "RISK_AWARENESS_ASSESSMENT",
-                            "requirement_status": "FAILED",
-                            "awaiting_action_from": "PAXOS",
-                            "errors": [
-                              {
-                                "code": "assessment_failed",
-                                "description": "Risk awareness assessment was not passed."
                               }
                             ]
                           },
@@ -135,7 +113,7 @@
                       "updated_at": "2026-04-21T11:00:00Z",
                       "institution_details": {
                         "name": "Acme Capital LLC",
-                        "document_verification_status": "DENIED"
+                        "document_verification_status": "APPROVED"
                       },
                       "institution_members": [
                         {
@@ -152,44 +130,12 @@
                           "roles": ["CONTROL_PERSON"],
                           "ownership": "49",
                           "name": "Jane Doe",
-                          "summary_status": "PENDING"
+                          "summary_status": "APPROVED"
                         }
                       ],
                       "status_details": {
-                        "active_controls": [
-                          {
-                            "id": "ctrl-002",
-                            "type": "SELL_ONLY",
-                            "set_by": "SET_BY_PAXOS",
-                            "is_overridable": true,
-                            "reason_code": "COMPLIANCE_EDD",
-                            "reason": "Account restricted pending enhanced due diligence completion.",
-                            "created_at": "2026-04-05T14:00:00Z"
-                          }
-                        ],
+                        "active_controls": [],
                         "requirements": [
-                          {
-                            "type": "DOCUMENT_VERIFICATION",
-                            "requirement_status": "FAILED",
-                            "awaiting_action_from": "PAXOS",
-                            "errors": [
-                              {
-                                "code": "document_verification_failed",
-                                "description": "Document verification could not be completed."
-                              }
-                            ]
-                          },
-                          {
-                            "type": "SCREENING_CHECK",
-                            "requirement_status": "PENDING",
-                            "awaiting_action_from": "PAXOS",
-                            "errors": [
-                              {
-                                "code": "screening_in_progress",
-                                "description": "Screening verification is in progress."
-                              }
-                            ]
-                          },
                           {
                             "type": "MEMBERS",
                             "requirement_status": "FAILED",

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -240,11 +240,11 @@
                             "member_list": [
                               {
                                 "identity_id": "b8e1f234-0011-4abc-9900-aabbccddeeff",
-                                "summary_status": "DENIED"
+                                "status": "DENIED"
                               },
                               {
                                 "identity_id": "c9f2a345-1122-5bcd-aa11-bbccddeeff00",
-                                "summary_status": "PENDING"
+                                "status": "PENDING"
                               }
                             ]
                           },
@@ -682,9 +682,9 @@
             "description": "The identity ID of the member.",
             "example": "b8e1f234-0011-4abc-9900-aabbccddeeff"
           },
-          "summary_status": {
+          "status": {
             "type": "string",
-            "description": "The summary status of the member identity.",
+            "description": "The status of the member identity.",
             "example": "DENIED"
           }
         }

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -77,7 +77,7 @@
                             "type": "ID_VERIFICATION",
                             "requirement_status": "FAILED",
                             "awaiting_action_from": "USER",
-                            "reason": "Your information could not be verified.",
+                            "reason": "ID Verification failed",
                             "errors": [
                               {
                                 "code": "submission_blurry",
@@ -89,7 +89,7 @@
                             "type": "SCREENING_CHECK",
                             "requirement_status": "PENDING",
                             "awaiting_action_from": "PAXOS",
-                            "reason": "Your information is under review.",
+                            "reason": "Screening Check pending",
                             "errors": [
                               {
                                 "code": "screening_match_detected",
@@ -101,7 +101,7 @@
                             "type": "COMPLIANCE_CHECK",
                             "requirement_status": "PENDING",
                             "awaiting_action_from": "PAXOS",
-                            "reason": "Your account is under review.",
+                            "reason": "Compliance Check pending",
                             "errors": [
                               {
                                 "code": "compliance_review_required",
@@ -113,7 +113,7 @@
                             "type": "RISK_AWARENESS_ASSESSMENT",
                             "requirement_status": "FAILED",
                             "awaiting_action_from": "USER",
-                            "reason": "Risk awareness assessment is required.",
+                            "reason": "Risk Awareness Assessment failed",
                             "errors": [
                               {
                                 "code": "assessment_not_completed",
@@ -125,7 +125,7 @@
                             "type": "KYC_REFRESH",
                             "requirement_status": "FAILED",
                             "awaiting_action_from": "USER",
-                            "reason": "Identity re-verification is required.",
+                            "reason": "KYC Refresh failed",
                             "errors": [
                               {
                                 "code": "kyc_refresh_overdue",
@@ -197,7 +197,7 @@
                             "type": "DOCUMENT_VERIFICATION",
                             "requirement_status": "FAILED",
                             "awaiting_action_from": "USER",
-                            "reason": "Document verification could not be completed.",
+                            "reason": "Document Verification failed",
                             "errors": [
                               {
                                 "code": "document_expired",
@@ -213,7 +213,7 @@
                             "type": "SCREENING_CHECK",
                             "requirement_status": "PENDING",
                             "awaiting_action_from": "PARTNER",
-                            "reason": "Your information is under review.",
+                            "reason": "Screening Check pending",
                             "errors": [
                               {
                                 "code": "screening_in_progress",
@@ -225,7 +225,7 @@
                             "type": "COMPLIANCE_CHECK",
                             "requirement_status": "PENDING",
                             "awaiting_action_from": "PAXOS",
-                            "reason": "Your account is under review.",
+                            "reason": "Compliance Check pending",
                             "errors": [
                               {
                                 "code": "compliance_review_required",
@@ -236,7 +236,7 @@
                           {
                             "type": "MEMBERS",
                             "requirement_status": "FAILED",
-                            "reason": "One or more members could not be verified.",
+                            "reason": "Members failed",
                             "member_statuses": [
                               {
                                 "identity_id": "b8e1f234-0011-4abc-9900-aabbccddeeff",
@@ -252,7 +252,7 @@
                             "type": "ENHANCED_DUE_DILIGENCE",
                             "requirement_status": "PENDING",
                             "awaiting_action_from": "USER",
-                            "reason": "Additional information is required.",
+                            "reason": "Enhanced Due Diligence pending",
                             "errors": [
                               {
                                 "code": "edd_documentation_required",
@@ -610,8 +610,8 @@
           },
           "reason": {
             "type": "string",
-            "description": "Human-readable description of the requirement status.",
-            "example": "Your information could not be verified."
+            "description": "Human-readable summary of the requirement status, in the format `<Type> <status>` (e.g., `ID Verification failed`, `Screening Check pending`).",
+            "example": "ID Verification failed"
           },
           "errors": {
             "type": "array",

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -75,7 +75,7 @@
                         "requirements": [
                           {
                             "type": "SCREENING_CHECK",
-                            "requirement_status": "PENDING",
+                            "status": "PENDING",
                             "awaiting_action_from": "PAXOS",
                             "errors": [
                               {
@@ -86,7 +86,7 @@
                           },
                           {
                             "type": "KYC_REFRESH",
-                            "requirement_status": "FAILED",
+                            "status": "FAILED",
                             "awaiting_action_from": "CLIENT",
                             "errors": [
                               {
@@ -138,7 +138,7 @@
                         "requirements": [
                           {
                             "type": "MEMBERS",
-                            "requirement_status": "FAILED",
+                            "status": "FAILED",
                             "errors": [
                               {
                                 "code": "member_verification_failed",
@@ -148,7 +148,7 @@
                           },
                           {
                             "type": "ENHANCED_DUE_DILIGENCE",
-                            "requirement_status": "PENDING",
+                            "status": "PENDING",
                             "awaiting_action_from": "CLIENT",
                             "errors": [
                               {
@@ -226,9 +226,8 @@
             "deprecated": true
           },
           "status": {
-            "type": "string",
-            "description": "The overall status of the identity.",
-            "example": "PENDING"
+            "allOf": [{ "$ref": "#/components/schemas/IdentitySummaryStatus" }],
+            "description": "The overall status of the identity."
           },
           "status_details": {
             "$ref": "#/components/schemas/IdentityStatusDetails"
@@ -499,12 +498,12 @@
       "Requirement": {
         "type": "object",
         "description": "A requirement associated with the identity's onboarding or compliance review. Requirements with `status: FAILED` indicate an action is needed; requirements with `status: PENDING` are under review.",
-        "required": ["type", "requirement_status"],
+        "required": ["type", "status"],
         "properties": {
           "type": {
             "$ref": "#/components/schemas/RequirementType"
           },
-          "requirement_status": {
+          "status": {
             "$ref": "#/components/schemas/RequirementStatus"
           },
           "awaiting_action_from": {
@@ -538,7 +537,9 @@
               "edd_documentation_required",
               "compliance_review_required",
               "compliance_review_failed",
-              "tin_not_found"
+              "tin_not_found",
+              "identity_verification_required",
+              "document_upload_required"
             ],
             "description": "Machine-readable error code. Additional codes may be added in the future.",
             "example": "identity_verification_failed"
@@ -560,10 +561,10 @@
           "ENHANCED_DUE_DILIGENCE",
           "RISK_AWARENESS_ASSESSMENT",
           "KYC_REFRESH",
-          "TIN_VERIFICATION",
+          "TAX_DETAILS_VERIFICATION",
           "MEMBERS"
         ],
-        "description": "The type of requirement.\n\n- `ID_VERIFICATION`: Government ID verification (person identities)\n- `DOCUMENT_VERIFICATION`: Business document review (institution identities)\n- `SCREENING_CHECK`: Background screening check\n- `COMPLIANCE_CHECK`: Internal compliance review\n- `ENHANCED_DUE_DILIGENCE`: Enhanced due diligence review\n- `RISK_AWARENESS_ASSESSMENT`: Risk awareness assessment (person identities)\n- `KYC_REFRESH`: Periodic re-verification of identity information\n- `TIN_VERIFICATION`: Tax identification number verification\n- `MEMBERS`: One or more institution members have outstanding requirements. Check `institution_members` in the response for details on which members are failing or pending"
+        "description": "The type of requirement.\n\n- `ID_VERIFICATION`: Government ID verification (person identities)\n- `DOCUMENT_VERIFICATION`: Business document review (institution identities)\n- `SCREENING_CHECK`: Background screening check\n- `COMPLIANCE_CHECK`: Internal compliance review\n- `ENHANCED_DUE_DILIGENCE`: Enhanced due diligence review\n- `RISK_AWARENESS_ASSESSMENT`: Risk awareness assessment (person identities)\n- `KYC_REFRESH`: Periodic re-verification of identity information\n- `TAX_DETAILS_VERIFICATION`: Tax identification number verification\n- `MEMBERS`: One or more institution members have outstanding requirements. Check `institution_members` in the response for details on which members are failing or pending"
       },
       "RequirementStatus": {
         "type": "string",

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -1,0 +1,449 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Paxos Identity API (Preview: Status Details)",
+    "version": "v2-preview"
+  },
+  "security": [
+    {
+      "OAuth2": ["identity:read_identity"]
+    }
+  ],
+  "paths": {
+    "/v2/identity/identities/{id}": {
+      "get": {
+        "summary": "Get Identity",
+        "description": "Retrieve a single identity by ID. This preview includes the updated `status_details` object with `pending_requirements` and `failed_requirements` fields.",
+        "operationId": "GetIdentityPreview",
+        "tags": ["Identity"],
+        "security": [
+          {
+            "OAuth2": ["identity:read_identity"]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The identity ID.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Identity"
+                },
+                "examples": {
+                  "pending_identity": {
+                    "summary": "Identity with pending and failed requirements",
+                    "value": {
+                      "id": "f190b163-208f-4d73-8deb-4fb8b24add00",
+                      "identity_type": "INSTITUTION",
+                      "summary_status": "PENDING",
+                      "created_at": "2024-01-15T10:00:00Z",
+                      "updated_at": "2024-01-15T10:30:00Z",
+                      "status_details": {
+                        "active_controls": [],
+                        "pending_requirements": [
+                          {
+                            "type": "ID_VERIFICATION",
+                            "message": "Pending ID Verification"
+                          },
+                          {
+                            "type": "DOCUMENT_VERIFICATION",
+                            "message": "Pending document verification"
+                          },
+                          {
+                            "type": "COMPLIANCE_CHECK",
+                            "message": "Pending compliance check"
+                          },
+                          {
+                            "type": "MEMBERS",
+                            "message": "Pending members",
+                            "member_list": [
+                              {
+                                "identity_id": "f190b163-208f-4d73-8deb-4fb8b24add00",
+                                "summary_status": "PENDING"
+                              }
+                            ]
+                          }
+                        ],
+                        "failed_requirements": [
+                          {
+                            "type": "DOCUMENT_VERIFICATION",
+                            "message": "Failed document verification"
+                          },
+                          {
+                            "type": "COMPLIANCE_CHECK",
+                            "message": "Failed compliance check"
+                          },
+                          {
+                            "type": "MEMBERS",
+                            "message": "Disabled members",
+                            "member_list": [
+                              {
+                                "identity_id": "a1b2c3d4-1234-5678-abcd-ef1234567890",
+                                "summary_status": "DISABLED"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "approved_identity": {
+                    "summary": "Approved identity with active control",
+                    "value": {
+                      "id": "a1b2c3d4-1234-5678-abcd-ef1234567890",
+                      "identity_type": "INDIVIDUAL",
+                      "summary_status": "APPROVED",
+                      "created_at": "2024-01-10T09:00:00Z",
+                      "updated_at": "2024-01-10T09:15:00Z",
+                      "status_details": {
+                        "active_controls": [
+                          {
+                            "id": "59b8e3c5-2b6e-4fa6-afcf-8c685598241d",
+                            "type": "SELL_ONLY",
+                            "set_by": "SET_BY_CLIENT",
+                            "is_overridable": true,
+                            "reason_code": "END_USER_REQUEST",
+                            "reason": "User requested sell-only mode",
+                            "created_at": "2024-01-10T09:15:00Z"
+                          }
+                        ],
+                        "pending_requirements": [],
+                        "failed_requirements": []
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "OAuth2": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "https://oauth.paxos.com/oauth2/token",
+            "scopes": {
+              "identity:read_identity": "Read identity data"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Identity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the identity.",
+            "example": "f190b163-208f-4d73-8deb-4fb8b24add00"
+          },
+          "identity_type": {
+            "$ref": "#/components/schemas/IdentityType"
+          },
+          "summary_status": {
+            "$ref": "#/components/schemas/IdentitySummaryStatus"
+          },
+          "status_details": {
+            "$ref": "#/components/schemas/IdentityStatusDetails"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Time the identity was created."
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Time the identity was last updated."
+          }
+        }
+      },
+      "IdentityType": {
+        "type": "string",
+        "enum": [
+          "INDIVIDUAL",
+          "INSTITUTION"
+        ],
+        "description": "The type of identity.\n\n- `INDIVIDUAL`: A natural person\n- `INSTITUTION`: A legal entity or business"
+      },
+      "IdentitySummaryStatus": {
+        "type": "string",
+        "enum": [
+          "PENDING",
+          "APPROVED",
+          "DENIED",
+          "DISABLED"
+        ],
+        "description": "The overall onboarding and compliance status of the identity.\n\n- `PENDING`: Identity is under review\n- `APPROVED`: Identity has passed all verifications and may transact\n- `DENIED`: Identity has been denied\n- `DISABLED`: Identity has been disabled and may not transact"
+      },
+      "IdentityStatusDetails": {
+        "type": "object",
+        "description": "Detailed breakdown of the identity's current status, including active restrictions and outstanding requirements.",
+        "properties": {
+          "active_controls": {
+            "type": "array",
+            "description": "Identity controls currently applied to this identity. See the [Identity Controls API](/api-reference/endpoints/identity-controls/overview) for details.",
+            "items": {
+              "$ref": "#/components/schemas/IdentityControl"
+            }
+          },
+          "pending_requirements": {
+            "type": "array",
+            "description": "Requirements that must be completed before the identity can be approved. Each entry describes a specific outstanding action.",
+            "items": {
+              "$ref": "#/components/schemas/PendingRequirement"
+            }
+          },
+          "failed_requirements": {
+            "type": "array",
+            "description": "Requirements that have failed verification. These indicate the reason an identity cannot be approved or has been disabled.",
+            "items": {
+              "$ref": "#/components/schemas/FailedRequirement"
+            }
+          }
+        }
+      },
+      "PendingRequirement": {
+        "type": "object",
+        "description": "An outstanding requirement that must be fulfilled before the identity can progress.",
+        "required": ["type", "message"],
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/PendingRequirementType"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable description of the pending requirement.",
+            "example": "Pending ID Verification"
+          },
+          "member_list": {
+            "type": "array",
+            "description": "For institution identities, the list of members with their current status. Only present when `type` is `MEMBERS`.",
+            "items": {
+              "$ref": "#/components/schemas/MemberStatus"
+            }
+          }
+        }
+      },
+      "FailedRequirement": {
+        "type": "object",
+        "description": "A requirement that has failed, preventing the identity from being approved or causing it to be disabled.",
+        "required": ["type", "message"],
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/FailedRequirementType"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable description of the failed requirement.",
+            "example": "Failed document verification"
+          },
+          "member_list": {
+            "type": "array",
+            "description": "For institution identities, the list of members with a failed status (disabled, denied, or error). Only present when `type` is `MEMBERS`.",
+            "items": {
+              "$ref": "#/components/schemas/MemberStatus"
+            }
+          }
+        }
+      },
+      "PendingRequirementType": {
+        "type": "string",
+        "enum": [
+          "ID_VERIFICATION",
+          "DOCUMENT_VERIFICATION",
+          "COMPLIANCE_CHECK",
+          "MEMBERS"
+        ],
+        "description": "The type of pending requirement.\n\n- `ID_VERIFICATION`: Identity verification (e.g., government ID check) is pending\n- `DOCUMENT_VERIFICATION`: Document review is pending\n- `COMPLIANCE_CHECK`: Compliance screening or review is pending\n- `MEMBERS`: One or more institution members have not yet completed their requirements"
+      },
+      "FailedRequirementType": {
+        "type": "string",
+        "enum": [
+          "ID_VERIFICATION",
+          "DOCUMENT_VERIFICATION",
+          "COMPLIANCE_CHECK",
+          "MEMBERS"
+        ],
+        "description": "The type of failed requirement.\n\n- `ID_VERIFICATION`: Identity verification failed\n- `DOCUMENT_VERIFICATION`: Document verification failed\n- `COMPLIANCE_CHECK`: Compliance check failed\n- `MEMBERS`: One or more institution members have a failed status (e.g., disabled, denied, or error)"
+      },
+      "MemberStatus": {
+        "type": "object",
+        "description": "Status of an institution member identity.",
+        "properties": {
+          "identity_id": {
+            "type": "string",
+            "description": "The identity ID of the member.",
+            "example": "f190b163-208f-4d73-8deb-4fb8b24add00"
+          },
+          "summary_status": {
+            "type": "string",
+            "description": "The summary status of the member identity.",
+            "example": "PENDING"
+          }
+        }
+      },
+      "IdentityControl": {
+        "type": "object",
+        "description": "An active control applied to an identity.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for this control."
+          },
+          "type": {
+            "type": "string",
+            "enum": ["SELL_ONLY", "CLOSED", "FROZEN", "DORMANT"],
+            "description": "The type of control applied to the identity."
+          },
+          "set_by": {
+            "type": "string",
+            "enum": ["SET_BY_PAXOS", "SET_BY_CLIENT"],
+            "description": "Indicates who set the control."
+          },
+          "is_overridable": {
+            "type": "boolean",
+            "description": "Whether this control can be deleted by the client application."
+          },
+          "reason_code": {
+            "type": "string",
+            "description": "Reason code for why the control was applied."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Freetext reason why this identity control was set."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Time this identity control was created."
+          },
+          "deleted_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Time this identity control was deleted."
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad Request",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string" },
+                "title": { "type": "string" },
+                "status": { "type": "integer" },
+                "detail": { "type": "string" }
+              }
+            },
+            "example": {
+              "type": "about:blank",
+              "title": "Bad Request",
+              "status": 400,
+              "detail": "Invalid request format or missing required fields"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string" },
+                "title": { "type": "string" },
+                "status": { "type": "integer" },
+                "detail": { "type": "string" }
+              }
+            },
+            "example": {
+              "type": "about:blank",
+              "title": "Unauthorized",
+              "status": 401,
+              "detail": "no authorization header set"
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Forbidden",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string" },
+                "title": { "type": "string" },
+                "status": { "type": "integer" },
+                "detail": { "type": "string" }
+              }
+            },
+            "example": {
+              "type": "about:blank",
+              "title": "Forbidden",
+              "status": 403,
+              "detail": "user account is disabled"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Not Found",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string" },
+                "title": { "type": "string" },
+                "status": { "type": "integer" },
+                "detail": { "type": "string" }
+              }
+            },
+            "example": {
+              "type": "about:blank",
+              "title": "Not Found",
+              "status": 404,
+              "detail": "identity not found"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -75,7 +75,7 @@
                         "requirements": [
                           {
                             "type": "ID_VERIFICATION",
-                            "requirements_status": "FAILED",
+                            "requirement_status": "FAILED",
                             "awaiting_action_from": "USER",
                             "reason": "Your information could not be verified.",
                             "errors": [
@@ -87,7 +87,7 @@
                           },
                           {
                             "type": "SCREENING_CHECK",
-                            "requirements_status": "PENDING",
+                            "requirement_status": "PENDING",
                             "awaiting_action_from": "PAXOS",
                             "reason": "Your information is under review.",
                             "errors": [
@@ -99,7 +99,7 @@
                           },
                           {
                             "type": "COMPLIANCE_CHECK",
-                            "requirements_status": "PENDING",
+                            "requirement_status": "PENDING",
                             "awaiting_action_from": "PAXOS",
                             "reason": "Your account is under review.",
                             "errors": [
@@ -111,7 +111,7 @@
                           },
                           {
                             "type": "RISK_AWARENESS_ASSESSMENT",
-                            "requirements_status": "FAILED",
+                            "requirement_status": "FAILED",
                             "awaiting_action_from": "USER",
                             "reason": "Risk awareness assessment is required.",
                             "errors": [
@@ -123,7 +123,7 @@
                           },
                           {
                             "type": "KYC_REFRESH",
-                            "requirements_status": "FAILED",
+                            "requirement_status": "FAILED",
                             "awaiting_action_from": "USER",
                             "reason": "Identity re-verification is required.",
                             "errors": [
@@ -195,7 +195,7 @@
                         "requirements": [
                           {
                             "type": "DOCUMENT_VERIFICATION",
-                            "requirements_status": "FAILED",
+                            "requirement_status": "FAILED",
                             "awaiting_action_from": "USER",
                             "reason": "Document verification could not be completed.",
                             "errors": [
@@ -211,7 +211,7 @@
                           },
                           {
                             "type": "SCREENING_CHECK",
-                            "requirements_status": "PENDING",
+                            "requirement_status": "PENDING",
                             "awaiting_action_from": "PARTNER",
                             "reason": "Your information is under review.",
                             "errors": [
@@ -223,7 +223,7 @@
                           },
                           {
                             "type": "COMPLIANCE_CHECK",
-                            "requirements_status": "PENDING",
+                            "requirement_status": "PENDING",
                             "awaiting_action_from": "PAXOS",
                             "reason": "Your account is under review.",
                             "errors": [
@@ -235,7 +235,7 @@
                           },
                           {
                             "type": "MEMBERS",
-                            "requirements_status": "FAILED",
+                            "requirement_status": "FAILED",
                             "reason": "One or more members could not be verified.",
                             "member_statuses": [
                               {
@@ -250,7 +250,7 @@
                           },
                           {
                             "type": "ENHANCED_DUE_DILIGENCE",
-                            "requirements_status": "PENDING",
+                            "requirement_status": "PENDING",
                             "awaiting_action_from": "USER",
                             "reason": "Additional information is required.",
                             "errors": [
@@ -596,12 +596,12 @@
       "Requirement": {
         "type": "object",
         "description": "A requirement associated with the identity's onboarding or compliance review. Requirements with `status: FAILED` indicate an action is needed; requirements with `status: PENDING` are under review.",
-        "required": ["type", "requirements_status"],
+        "required": ["type", "requirement_status"],
         "properties": {
           "type": {
             "$ref": "#/components/schemas/RequirementType"
           },
-          "requirements_status": {
+          "requirement_status": {
             "$ref": "#/components/schemas/RequirementStatus"
           },
           "awaiting_action_from": {

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -42,7 +42,7 @@
                 },
                 "examples": {
                   "person_denied": {
-                    "summary": "Person identity denied due to failed risk awareness assessment",
+                    "summary": "Person identity denied with pending EDD and failed requirements",
                     "value": {
                       "id": "c3d4e5f6-0000-0000-0000-000000000001",
                       "ref_id": "user-001",
@@ -69,11 +69,20 @@
                       "summary_tin_verification_status": "VALID",
                       "status_details": {
                         "active_controls": [],
-                        "pending_requirements": [],
+                        "pending_requirements": [
+                          {
+                            "type": "ENHANCED_DUE_DILIGENCE",
+                            "message": "Pending enhanced due diligence"
+                          }
+                        ],
                         "failed_requirements": [
                           {
                             "type": "RISK_AWARENESS_ASSESSMENT",
                             "message": "Failed PTE Risk Awareness Assessment"
+                          },
+                          {
+                            "type": "KYC_REFRESH",
+                            "message": "KYC refresh required"
                           }
                         ]
                       },
@@ -97,8 +106,8 @@
                       "is_merchant": false,
                       "institution_details": {
                         "name": "Acme Corp",
-                        "sanctions_verification_status": "APPROVED",
-                        "document_verification_status": "DENIED",
+                        "sanctions_verification_status": "PENDING",
+                        "document_verification_status": "PENDING",
                         "institution_type": "CORPORATION",
                         "institution_sub_type": "PRIVATE",
                         "business_address": {
@@ -152,6 +161,14 @@
                         ],
                         "pending_requirements": [
                           {
+                            "type": "DOCUMENT_VERIFICATION",
+                            "message": "Pending document verification"
+                          },
+                          {
+                            "type": "SCREENING_CHECK",
+                            "message": "Pending screening check"
+                          },
+                          {
                             "type": "COMPLIANCE_CHECK",
                             "message": "Pending compliance check"
                           },
@@ -167,10 +184,6 @@
                           }
                         ],
                         "failed_requirements": [
-                          {
-                            "type": "DOCUMENT_VERIFICATION",
-                            "message": "Failed document verification"
-                          },
                           {
                             "type": "MEMBERS",
                             "message": "Failed members",
@@ -569,10 +582,12 @@
         "enum": [
           "ID_VERIFICATION",
           "DOCUMENT_VERIFICATION",
+          "SCREENING_CHECK",
           "COMPLIANCE_CHECK",
+          "ENHANCED_DUE_DILIGENCE",
           "MEMBERS"
         ],
-        "description": "The type of pending requirement.\n\n- `ID_VERIFICATION`: Identity verification (e.g., government ID check) is pending\n- `DOCUMENT_VERIFICATION`: Document review is pending\n- `COMPLIANCE_CHECK`: Compliance screening or review is pending\n- `MEMBERS`: One or more institution members have not yet completed their requirements"
+        "description": "The type of pending requirement.\n\n- `ID_VERIFICATION`: Identity verification (e.g., government ID check) is pending\n- `DOCUMENT_VERIFICATION`: Document review is pending\n- `SCREENING_CHECK`: Sanctions or other screening check is pending\n- `COMPLIANCE_CHECK`: Compliance review is pending\n- `ENHANCED_DUE_DILIGENCE`: Enhanced due diligence review is pending\n- `MEMBERS`: One or more institution members have not yet completed their requirements"
       },
       "FailedRequirementType": {
         "type": "string",
@@ -581,9 +596,10 @@
           "DOCUMENT_VERIFICATION",
           "COMPLIANCE_CHECK",
           "MEMBERS",
-          "RISK_AWARENESS_ASSESSMENT"
+          "RISK_AWARENESS_ASSESSMENT",
+          "KYC_REFRESH"
         ],
-        "description": "The type of failed requirement.\n\n- `ID_VERIFICATION`: Identity verification failed\n- `DOCUMENT_VERIFICATION`: Document verification failed\n- `COMPLIANCE_CHECK`: Compliance check failed\n- `MEMBERS`: One or more institution members have a failed status (e.g., disabled, denied, or error)\n- `RISK_AWARENESS_ASSESSMENT`: Risk awareness assessment failed"
+        "description": "The type of failed requirement.\n\n- `ID_VERIFICATION`: Identity verification failed\n- `DOCUMENT_VERIFICATION`: Document verification failed\n- `COMPLIANCE_CHECK`: Compliance check failed\n- `MEMBERS`: One or more institution members have a failed status (e.g., disabled, denied, or error)\n- `RISK_AWARENESS_ASSESSMENT`: Risk awareness assessment failed\n- `KYC_REFRESH`: KYC refresh is required"
       },
       "MemberStatus": {
         "type": "object",

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -615,7 +615,7 @@
           },
           "errors": {
             "type": "array",
-            "description": "Specific error details for this requirement. Not present on `MEMBERS` type requirements. **Coming soon** — this field will be added in a future release.",
+            "description": "Specific error details for developer use only. Do not expose `code` or `description` values directly to end users — use `reason` for user-facing messaging. Not present on `MEMBERS` type requirements. **Coming soon** — this field will be added in a future release.",
             "items": {
               "$ref": "#/components/schemas/RequirementError"
             }
@@ -635,7 +635,7 @@
         "properties": {
           "code": {
             "type": "string",
-            "description": "Machine-readable error code.",
+            "description": "Machine-readable error code. Will be a fixed enum of values in the final release.",
             "example": "submission_blurry"
           },
           "description": {

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -342,11 +342,10 @@
       "IdentityType": {
         "type": "string",
         "enum": [
-          "INDIVIDUAL",
-          "INSTITUTION",
-          "PERSON"
+          "PERSON",
+          "INSTITUTION"
         ],
-        "description": "The type of identity.\n\n- `INDIVIDUAL`: A natural person\n- `INSTITUTION`: A legal entity or business\n- `PERSON`: A person associated with an institution (e.g., beneficial owner or control person)"
+        "description": "The type of identity.\n\n- `PERSON`: A natural person\n- `INSTITUTION`: A legal entity or business"
       },
       "IdentitySummaryStatus": {
         "type": "string",

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -13,7 +13,7 @@
     "/v2/identity/identities/{id}": {
       "get": {
         "summary": "Get Identity",
-        "description": "Retrieve a single identity by ID. This preview includes the updated `status_details` object with `pending_requirements` and `failed_requirements` fields.",
+        "description": "Retrieve a single identity by ID. This preview includes the updated `status_details` object with a unified `requirements` array containing both pending and failed requirements.",
         "operationId": "GetIdentityPreview",
         "tags": ["Identity"],
         "security": [
@@ -41,159 +41,227 @@
                   "$ref": "#/components/schemas/Identity"
                 },
                 "examples": {
-                  "person_denied": {
-                    "summary": "Person identity denied with pending EDD and failed requirements",
+                  "person_pending": {
+                    "summary": "Person identity pending with failed and pending requirements",
                     "value": {
-                      "id": "c3d4e5f6-0000-0000-0000-000000000001",
-                      "ref_id": "user-001",
+                      "id": "f190b163-208f-4d73-8deb-4fb8b24add00",
                       "type": "PERSON",
-                      "metadata": {},
-                      "summary_status": "DENIED",
-                      "status": "DENIED",
+                      "ref_id": "user-abc-123",
+                      "status": "PENDING",
+                      "summary_status": "PENDING",
                       "user_disabled": false,
                       "admin_disabled": false,
-                      "is_merchant": false,
+                      "created_at": "2026-04-01T10:00:00Z",
+                      "updated_at": "2026-04-15T09:30:00Z",
                       "person_details": {
-                        "first_name": "Alice",
-                        "last_name": "Johnson",
+                        "first_name": "Jane",
+                        "last_name": "Smith",
                         "date_of_birth": "1990-05-15",
-                        "id_verification_status": "APPROVED",
-                        "sanctions_verification_status": "APPROVED"
+                        "id_verification_status": "DENIED",
+                        "sanctions_verification_status": "PENDING"
                       },
-                      "tax_details": [
-                        {
-                          "tax_id_type": "SSN",
-                          "tin_verification_status": "VALID"
-                        }
-                      ],
-                      "summary_tin_verification_status": "VALID",
                       "status_details": {
-                        "active_controls": [],
-                        "pending_requirements": [
+                        "active_controls": [
                           {
-                            "type": "ENHANCED_DUE_DILIGENCE",
-                            "message": "Pending enhanced due diligence"
+                            "id": "ctrl-001",
+                            "type": "FROZEN",
+                            "set_by": "SET_BY_PAXOS",
+                            "is_overridable": false,
+                            "reason_code": "COMPLIANCE_KYC",
+                            "reason": "Account frozen pending identity re-verification.",
+                            "created_at": "2026-04-10T08:00:00Z"
                           }
                         ],
-                        "failed_requirements": [
+                        "requirements": [
+                          {
+                            "type": "ID_VERIFICATION",
+                            "status": "FAILED",
+                            "awaiting_action_from": "USER",
+                            "reason": "Your information could not be verified.",
+                            "errors": [
+                              {
+                                "code": "submission_blurry",
+                                "description": "Cannot validate ID — upload a photo of your ID that is clear"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SCREENING_CHECK",
+                            "status": "PENDING",
+                            "awaiting_action_from": "PAXOS",
+                            "reason": "Your information is under review.",
+                            "errors": [
+                              {
+                                "code": "screening_match_detected",
+                                "description": "Your information requires manual review."
+                              }
+                            ]
+                          },
+                          {
+                            "type": "COMPLIANCE_CHECK",
+                            "status": "PENDING",
+                            "awaiting_action_from": "PAXOS",
+                            "reason": "Your account is under review.",
+                            "errors": [
+                              {
+                                "code": "compliance_review_required",
+                                "description": "Your account has been flagged for compliance review."
+                              }
+                            ]
+                          },
+                          {
+                            "type": "RISK_AWARENESS_ASSESSMENT",
+                            "status": "FAILED",
+                            "awaiting_action_from": "USER",
+                            "reason": "Risk awareness assessment is required.",
+                            "errors": [
+                              {
+                                "code": "assessment_not_completed",
+                                "description": "Risk awareness assessment must be completed."
+                              }
+                            ]
+                          },
                           {
                             "type": "KYC_REFRESH",
-                            "message": "KYC refresh required"
+                            "status": "FAILED",
+                            "awaiting_action_from": "USER",
+                            "reason": "Identity re-verification is required.",
+                            "errors": [
+                              {
+                                "code": "kyc_refresh_overdue",
+                                "description": "Your identity verification has expired and must be renewed."
+                              }
+                            ]
                           }
                         ]
-                      },
-                      "created_at": "2026-03-15T08:00:00Z",
-                      "updated_at": "2026-04-05T14:30:00Z"
+                      }
                     }
                   },
                   "institution_pending": {
                     "summary": "Institution identity with pending and failed requirements",
                     "value": {
-                      "id": "f190b163-208f-4d73-8deb-4fb8b24add00",
-                      "ref_id": "acme-corp",
+                      "id": "a3c2d891-ff14-4a02-b891-7700de3c1200",
                       "type": "INSTITUTION",
-                      "metadata": {
-                        "customer_ref": "acme-corp-001"
-                      },
-                      "summary_status": "PENDING",
+                      "ref_id": "inst-xyz-456",
                       "status": "PENDING",
+                      "summary_status": "PENDING",
                       "user_disabled": false,
                       "admin_disabled": false,
-                      "is_merchant": false,
+                      "created_at": "2026-03-15T08:00:00Z",
+                      "updated_at": "2026-04-15T11:00:00Z",
                       "institution_details": {
-                        "name": "Acme Corp",
-                        "sanctions_verification_status": "PENDING",
-                        "document_verification_status": "PENDING",
-                        "institution_type": "CORPORATION",
-                        "institution_sub_type": "PRIVATE",
-                        "business_address": {
-                          "address_line_1": "123 Main St",
-                          "city": "New York",
-                          "state": "NY",
-                          "zip": "10001",
-                          "country": "USA"
-                        },
-                        "phone_number": "+12125550100",
-                        "email": "compliance@acmecorp.com"
+                        "name": "Acme Capital LLC",
+                        "document_verification_status": "DENIED"
                       },
                       "institution_members": [
                         {
-                          "id": "m1b2c3d4-0000-0000-0000-000000000001",
-                          "identity_id": "b2c3d4e5-0000-0000-0000-000000000001",
-                          "name": "Jane Smith",
-                          "roles": ["BENEFICIAL_OWNER", "CONTROL_PERSON"],
+                          "id": "m1",
+                          "identity_id": "b8e1f234-0011-4abc-9900-aabbccddeeff",
+                          "roles": ["BENEFICIAL_OWNER"],
                           "ownership": "51",
-                          "position": "CEO",
-                          "summary_status": "PENDING"
+                          "name": "John Doe",
+                          "summary_status": "DENIED"
                         },
                         {
-                          "id": "m1b2c3d4-0000-0000-0000-000000000002",
-                          "identity_id": "a1b2c3d4-1234-5678-abcd-ef1234567890",
-                          "name": "John Doe",
-                          "roles": ["BENEFICIAL_OWNER"],
+                          "id": "m2",
+                          "identity_id": "c9f2a345-1122-5bcd-aa11-bbccddeeff00",
+                          "roles": ["CONTROL_PERSON"],
                           "ownership": "49",
-                          "position": "CFO",
-                          "summary_status": "DISABLED"
+                          "name": "Jane Doe",
+                          "summary_status": "PENDING"
                         }
                       ],
-                      "tax_details": [
-                        {
-                          "tax_id_type": "EIN",
-                          "tin_verification_status": "VALID"
-                        }
-                      ],
-                      "summary_tin_verification_status": "VALID",
                       "status_details": {
                         "active_controls": [
                           {
-                            "id": "ctrl-0000-0000-0000-000000000001",
+                            "id": "ctrl-002",
                             "type": "SELL_ONLY",
                             "set_by": "SET_BY_PAXOS",
-                            "is_overridable": false,
-                            "reason_code": "COMPLIANCE_KYC",
-                            "reason": "Identity pending full KYC review",
-                            "created_at": "2026-03-01T10:00:00Z"
+                            "is_overridable": true,
+                            "reason_code": "COMPLIANCE_EDD",
+                            "reason": "Account restricted pending enhanced due diligence completion.",
+                            "created_at": "2026-04-05T14:00:00Z"
+                          },
+                          {
+                            "id": "ctrl-003",
+                            "type": "DORMANT",
+                            "set_by": "SET_BY_CLIENT",
+                            "is_overridable": true,
+                            "reason_code": "INACTIVITY",
+                            "reason": "Account marked dormant due to prolonged inactivity.",
+                            "created_at": "2026-03-01T00:00:00Z"
                           }
                         ],
-                        "pending_requirements": [
+                        "requirements": [
                           {
                             "type": "DOCUMENT_VERIFICATION",
-                            "message": "Pending document verification"
+                            "status": "FAILED",
+                            "awaiting_action_from": "USER",
+                            "reason": "Document verification could not be completed.",
+                            "errors": [
+                              {
+                                "code": "document_expired",
+                                "description": "Submitted document is expired"
+                              },
+                              {
+                                "code": "document_unreadable",
+                                "description": "Submitted documents could not be verified"
+                              }
+                            ]
                           },
                           {
                             "type": "SCREENING_CHECK",
-                            "message": "Pending screening check"
+                            "status": "PENDING",
+                            "awaiting_action_from": "PARTNER",
+                            "reason": "Your information is under review.",
+                            "errors": [
+                              {
+                                "code": "screening_in_progress",
+                                "description": "Screening verification is in progress."
+                              }
+                            ]
                           },
                           {
                             "type": "COMPLIANCE_CHECK",
-                            "message": "Pending compliance check"
+                            "status": "PENDING",
+                            "awaiting_action_from": "PAXOS",
+                            "reason": "Your account is under review.",
+                            "errors": [
+                              {
+                                "code": "compliance_review_required",
+                                "description": "Your account has been flagged for compliance review."
+                              }
+                            ]
                           },
                           {
                             "type": "MEMBERS",
-                            "message": "Pending members",
+                            "status": "FAILED",
+                            "reason": "One or more members could not be verified.",
                             "member_list": [
                               {
-                                "identity_id": "b2c3d4e5-0000-0000-0000-000000000001",
+                                "identity_id": "b8e1f234-0011-4abc-9900-aabbccddeeff",
+                                "summary_status": "DENIED"
+                              },
+                              {
+                                "identity_id": "c9f2a345-1122-5bcd-aa11-bbccddeeff00",
                                 "summary_status": "PENDING"
                               }
                             ]
-                          }
-                        ],
-                        "failed_requirements": [
+                          },
                           {
-                            "type": "MEMBERS",
-                            "message": "Failed members",
-                            "member_list": [
+                            "type": "ENHANCED_DUE_DILIGENCE",
+                            "status": "PENDING",
+                            "awaiting_action_from": "USER",
+                            "reason": "Additional information is required.",
+                            "errors": [
                               {
-                                "identity_id": "a1b2c3d4-1234-5678-abcd-ef1234567890",
-                                "summary_status": "DISABLED"
+                                "code": "edd_documentation_required",
+                                "description": "Additional documentation is required to complete enhanced due diligence review."
                               }
                             ]
                           }
                         ]
-                      },
-                      "created_at": "2026-03-01T09:00:00Z",
-                      "updated_at": "2026-04-01T12:00:00Z"
+                      }
                     }
                   }
                 }
@@ -242,7 +310,7 @@
           "ref_id": {
             "type": "string",
             "description": "Client-provided reference ID for the identity.",
-            "example": "acme-corp"
+            "example": "user-abc-123"
           },
           "type": {
             "$ref": "#/components/schemas/IdentityType"
@@ -344,12 +412,12 @@
           "first_name": {
             "type": "string",
             "description": "First name of the person.",
-            "example": "Alice"
+            "example": "Jane"
           },
           "last_name": {
             "type": "string",
             "description": "Last name of the person.",
-            "example": "Johnson"
+            "example": "Smith"
           },
           "date_of_birth": {
             "type": "string",
@@ -360,12 +428,12 @@
           "id_verification_status": {
             "type": "string",
             "description": "Status of government ID verification.",
-            "example": "APPROVED"
+            "example": "DENIED"
           },
           "sanctions_verification_status": {
             "type": "string",
             "description": "Status of sanctions screening.",
-            "example": "APPROVED"
+            "example": "PENDING"
           }
         }
       },
@@ -376,7 +444,7 @@
           "name": {
             "type": "string",
             "description": "Legal name of the institution.",
-            "example": "Acme Corp"
+            "example": "Acme Capital LLC"
           },
           "sanctions_verification_status": {
             "type": "string",
@@ -449,17 +517,17 @@
           "id": {
             "type": "string",
             "description": "Unique identifier for the membership record.",
-            "example": "m1b2c3d4-0000-0000-0000-000000000001"
+            "example": "m1"
           },
           "identity_id": {
             "type": "string",
             "description": "The identity ID of the member.",
-            "example": "b2c3d4e5-0000-0000-0000-000000000001"
+            "example": "b8e1f234-0011-4abc-9900-aabbccddeeff"
           },
           "name": {
             "type": "string",
             "description": "Full name of the member.",
-            "example": "Jane Smith"
+            "example": "John Doe"
           },
           "roles": {
             "type": "array",
@@ -467,7 +535,7 @@
             "items": {
               "type": "string"
             },
-            "example": ["BENEFICIAL_OWNER", "CONTROL_PERSON"]
+            "example": ["BENEFICIAL_OWNER"]
           },
           "ownership": {
             "type": "string",
@@ -482,7 +550,7 @@
           "summary_status": {
             "type": "string",
             "description": "The summary status of the member's identity.",
-            "example": "PENDING"
+            "example": "DENIED"
           }
         }
       },
@@ -513,34 +581,41 @@
               "$ref": "#/components/schemas/IdentityControl"
             }
           },
-          "pending_requirements": {
+          "requirements": {
             "type": "array",
-            "description": "Requirements that must be completed before the identity can be approved. Each entry describes a specific outstanding action.",
+            "description": "All outstanding requirements for this identity, including both pending and failed entries. Each requirement includes its current `status` and, where applicable, the `awaiting_action_from` party and error details.",
             "items": {
-              "$ref": "#/components/schemas/PendingRequirement"
-            }
-          },
-          "failed_requirements": {
-            "type": "array",
-            "description": "Requirements that have failed verification. These indicate the reason an identity cannot be approved or has been disabled.",
-            "items": {
-              "$ref": "#/components/schemas/FailedRequirement"
+              "$ref": "#/components/schemas/Requirement"
             }
           }
         }
       },
-      "PendingRequirement": {
+      "Requirement": {
         "type": "object",
-        "description": "An outstanding requirement that must be fulfilled before the identity can progress.",
-        "required": ["type", "message"],
+        "description": "A requirement associated with the identity's onboarding or compliance review. Requirements with `status: FAILED` indicate an action is needed; requirements with `status: PENDING` are under review.",
+        "required": ["type", "status"],
         "properties": {
           "type": {
-            "$ref": "#/components/schemas/PendingRequirementType"
+            "$ref": "#/components/schemas/RequirementType"
           },
-          "message": {
+          "status": {
+            "$ref": "#/components/schemas/RequirementStatus"
+          },
+          "awaiting_action_from": {
+            "allOf": [{ "$ref": "#/components/schemas/AwaitingActionFrom" }],
+            "description": "Indicates who must act to resolve the requirement. Not present on `MEMBERS` type requirements. **Coming soon** — this field will be added in a future release."
+          },
+          "reason": {
             "type": "string",
-            "description": "Human-readable description of the pending requirement.",
-            "example": "Pending compliance check"
+            "description": "Human-readable description of the requirement status.",
+            "example": "Your information could not be verified."
+          },
+          "errors": {
+            "type": "array",
+            "description": "Specific error details for this requirement. Not present on `MEMBERS` type requirements. **Coming soon** — this field will be added in a future release.",
+            "items": {
+              "$ref": "#/components/schemas/RequirementError"
+            }
           },
           "member_list": {
             "type": "array",
@@ -551,29 +626,23 @@
           }
         }
       },
-      "FailedRequirement": {
+      "RequirementError": {
         "type": "object",
-        "description": "A requirement that has failed, preventing the identity from being approved or causing it to be disabled.",
-        "required": ["type", "message"],
+        "description": "A specific error associated with a failed or pending requirement.",
         "properties": {
-          "type": {
-            "$ref": "#/components/schemas/FailedRequirementType"
-          },
-          "message": {
+          "code": {
             "type": "string",
-            "description": "Human-readable description of the failed requirement.",
-            "example": "Failed document verification"
+            "description": "Machine-readable error code.",
+            "example": "submission_blurry"
           },
-          "member_list": {
-            "type": "array",
-            "description": "For institution identities, the list of members with a failed status (disabled, denied, or error). Only present when `type` is `MEMBERS`.",
-            "items": {
-              "$ref": "#/components/schemas/MemberStatus"
-            }
+          "description": {
+            "type": "string",
+            "description": "Human-readable description of the error.",
+            "example": "Cannot validate ID — upload a photo of your ID that is clear"
           }
         }
       },
-      "PendingRequirementType": {
+      "RequirementType": {
         "type": "string",
         "enum": [
           "ID_VERIFICATION",
@@ -581,20 +650,28 @@
           "SCREENING_CHECK",
           "COMPLIANCE_CHECK",
           "ENHANCED_DUE_DILIGENCE",
+          "RISK_AWARENESS_ASSESSMENT",
+          "KYC_REFRESH",
           "MEMBERS"
         ],
-        "description": "The type of pending requirement.\n\n- `ID_VERIFICATION`: Identity verification (e.g., government ID check) is pending\n- `DOCUMENT_VERIFICATION`: Document review is pending\n- `SCREENING_CHECK`: Sanctions or other screening check is pending\n- `COMPLIANCE_CHECK`: Compliance review is pending\n- `ENHANCED_DUE_DILIGENCE`: Enhanced due diligence review is pending\n- `MEMBERS`: One or more institution members have not yet completed their requirements"
+        "description": "The type of requirement.\n\n- `ID_VERIFICATION`: Government ID verification (person identities)\n- `DOCUMENT_VERIFICATION`: Business document review (institution identities)\n- `SCREENING_CHECK`: Sanctions or watchlist screening\n- `COMPLIANCE_CHECK`: Internal compliance review\n- `ENHANCED_DUE_DILIGENCE`: Enhanced due diligence review\n- `RISK_AWARENESS_ASSESSMENT`: Risk awareness assessment (person identities)\n- `KYC_REFRESH`: Periodic re-verification of identity information\n- `MEMBERS`: One or more institution members have outstanding requirements"
       },
-      "FailedRequirementType": {
+      "RequirementStatus": {
         "type": "string",
         "enum": [
-          "ID_VERIFICATION",
-          "DOCUMENT_VERIFICATION",
-          "COMPLIANCE_CHECK",
-          "MEMBERS",
-          "KYC_REFRESH"
+          "PENDING",
+          "FAILED"
         ],
-        "description": "The type of failed requirement.\n\n- `ID_VERIFICATION`: Identity verification failed\n- `DOCUMENT_VERIFICATION`: Document verification failed\n- `COMPLIANCE_CHECK`: Compliance check failed\n- `MEMBERS`: One or more institution members have a failed status (e.g., disabled, denied, or error)\n- `KYC_REFRESH`: KYC refresh is required"
+        "description": "The status of the requirement.\n\n- `PENDING`: The requirement has not yet been fulfilled. May be under review by Paxos or a partner, or may require action from the user — check `awaiting_action_from` for details.\n- `FAILED`: The requirement was not met. May or may not require action — check `awaiting_action_from` for details."
+      },
+      "AwaitingActionFrom": {
+        "type": "string",
+        "enum": [
+          "USER",
+          "PAXOS",
+          "PARTNER"
+        ],
+        "description": "Indicates who must act to resolve the requirement.\n\n- `USER`: The end user must take action (e.g., resubmit a document)\n- `PAXOS`: Paxos is reviewing and no action is needed from the user\n- `PARTNER`: The partner (client application) must take action"
       },
       "MemberStatus": {
         "type": "object",
@@ -603,12 +680,12 @@
           "identity_id": {
             "type": "string",
             "description": "The identity ID of the member.",
-            "example": "b2c3d4e5-0000-0000-0000-000000000001"
+            "example": "b8e1f234-0011-4abc-9900-aabbccddeeff"
           },
           "summary_status": {
             "type": "string",
             "description": "The summary status of the member identity.",
-            "example": "PENDING"
+            "example": "DENIED"
           }
         }
       },

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -52,7 +52,7 @@
                       "user_disabled": false,
                       "admin_disabled": false,
                       "created_at": "2026-04-01T10:00:00Z",
-                      "updated_at": "2026-04-15T09:30:00Z",
+                      "updated_at": "2026-04-21T09:30:00Z",
                       "person_details": {
                         "first_name": "Jane",
                         "last_name": "Smith",
@@ -76,12 +76,11 @@
                           {
                             "type": "ID_VERIFICATION",
                             "requirement_status": "FAILED",
-                            "awaiting_action_from": "USER",
-                            "reason": "ID Verification failed",
+                            "awaiting_action_from": "PAXOS",
                             "errors": [
                               {
-                                "code": "submission_blurry",
-                                "description": "Cannot validate ID — upload a photo of your ID that is clear"
+                                "code": "identity_verification_failed",
+                                "description": "Identity verification could not be completed."
                               }
                             ]
                           },
@@ -89,47 +88,32 @@
                             "type": "SCREENING_CHECK",
                             "requirement_status": "PENDING",
                             "awaiting_action_from": "PAXOS",
-                            "reason": "Screening Check pending",
                             "errors": [
                               {
-                                "code": "screening_match_detected",
-                                "description": "Your information requires manual review."
-                              }
-                            ]
-                          },
-                          {
-                            "type": "COMPLIANCE_CHECK",
-                            "requirement_status": "PENDING",
-                            "awaiting_action_from": "PAXOS",
-                            "reason": "Compliance Check pending",
-                            "errors": [
-                              {
-                                "code": "compliance_review_required",
-                                "description": "Your account has been flagged for compliance review."
+                                "code": "screening_in_progress",
+                                "description": "Screening verification is in progress."
                               }
                             ]
                           },
                           {
                             "type": "RISK_AWARENESS_ASSESSMENT",
                             "requirement_status": "FAILED",
-                            "awaiting_action_from": "USER",
-                            "reason": "Risk Awareness Assessment failed",
+                            "awaiting_action_from": "PAXOS",
                             "errors": [
                               {
-                                "code": "assessment_not_completed",
-                                "description": "Risk awareness assessment must be completed."
+                                "code": "assessment_failed",
+                                "description": "Risk awareness assessment was not passed."
                               }
                             ]
                           },
                           {
                             "type": "KYC_REFRESH",
                             "requirement_status": "FAILED",
-                            "awaiting_action_from": "USER",
-                            "reason": "KYC Refresh failed",
+                            "awaiting_action_from": "CLIENT",
                             "errors": [
                               {
                                 "code": "kyc_refresh_overdue",
-                                "description": "Your identity verification has expired and must be renewed."
+                                "description": "Identity verification has expired and must be renewed."
                               }
                             ]
                           }
@@ -148,7 +132,7 @@
                       "user_disabled": false,
                       "admin_disabled": false,
                       "created_at": "2026-03-15T08:00:00Z",
-                      "updated_at": "2026-04-15T11:00:00Z",
+                      "updated_at": "2026-04-21T11:00:00Z",
                       "institution_details": {
                         "name": "Acme Capital LLC",
                         "document_verification_status": "DENIED"
@@ -181,39 +165,24 @@
                             "reason_code": "COMPLIANCE_EDD",
                             "reason": "Account restricted pending enhanced due diligence completion.",
                             "created_at": "2026-04-05T14:00:00Z"
-                          },
-                          {
-                            "id": "ctrl-003",
-                            "type": "DORMANT",
-                            "set_by": "SET_BY_CLIENT",
-                            "is_overridable": true,
-                            "reason_code": "INACTIVITY",
-                            "reason": "Account marked dormant due to prolonged inactivity.",
-                            "created_at": "2026-03-01T00:00:00Z"
                           }
                         ],
                         "requirements": [
                           {
                             "type": "DOCUMENT_VERIFICATION",
                             "requirement_status": "FAILED",
-                            "awaiting_action_from": "USER",
-                            "reason": "Document Verification failed",
+                            "awaiting_action_from": "PAXOS",
                             "errors": [
                               {
-                                "code": "document_expired",
-                                "description": "Submitted document is expired"
-                              },
-                              {
-                                "code": "document_unreadable",
-                                "description": "Submitted documents could not be verified"
+                                "code": "document_verification_failed",
+                                "description": "Document verification could not be completed."
                               }
                             ]
                           },
                           {
                             "type": "SCREENING_CHECK",
                             "requirement_status": "PENDING",
-                            "awaiting_action_from": "PARTNER",
-                            "reason": "Screening Check pending",
+                            "awaiting_action_from": "PAXOS",
                             "errors": [
                               {
                                 "code": "screening_in_progress",
@@ -222,37 +191,19 @@
                             ]
                           },
                           {
-                            "type": "COMPLIANCE_CHECK",
-                            "requirement_status": "PENDING",
-                            "awaiting_action_from": "PAXOS",
-                            "reason": "Compliance Check pending",
-                            "errors": [
-                              {
-                                "code": "compliance_review_required",
-                                "description": "Your account has been flagged for compliance review."
-                              }
-                            ]
-                          },
-                          {
                             "type": "MEMBERS",
                             "requirement_status": "FAILED",
-                            "reason": "Members failed",
-                            "member_statuses": [
+                            "errors": [
                               {
-                                "identity_id": "b8e1f234-0011-4abc-9900-aabbccddeeff",
-                                "status": "DENIED"
-                              },
-                              {
-                                "identity_id": "c9f2a345-1122-5bcd-aa11-bbccddeeff00",
-                                "status": "PENDING"
+                                "code": "member_verification_failed",
+                                "description": "One or more members could not be verified."
                               }
                             ]
                           },
                           {
                             "type": "ENHANCED_DUE_DILIGENCE",
                             "requirement_status": "PENDING",
-                            "awaiting_action_from": "USER",
-                            "reason": "Enhanced Due Diligence pending",
+                            "awaiting_action_from": "CLIENT",
                             "errors": [
                               {
                                 "code": "edd_documentation_required",
@@ -606,42 +557,43 @@
           },
           "awaiting_action_from": {
             "allOf": [{ "$ref": "#/components/schemas/AwaitingActionFrom" }],
-            "description": "Indicates who must act to resolve the requirement. Not present on `MEMBERS` type requirements. **Coming soon** — this field will be added in a future release."
-          },
-          "reason": {
-            "type": "string",
-            "description": "Human-readable summary of the requirement status, in the format `<Type> <status>` (e.g., `ID Verification failed`, `Screening Check pending`).",
-            "example": "ID Verification failed"
+            "description": "Indicates who must act to resolve the requirement. Not present on `MEMBERS` type requirements."
           },
           "errors": {
             "type": "array",
-            "description": "Specific error details for developer use only. Do not expose `code` or `description` values directly to end users — use `reason` for user-facing messaging. Not present on `MEMBERS` type requirements. **Coming soon** — this field will be added in a future release.",
+            "description": "Specific error details for developer use only. Do not expose `code` or `description` values directly to end users. `code` is a fixed enum of values; additional codes may be added in the future.",
             "items": {
               "$ref": "#/components/schemas/RequirementError"
-            }
-          },
-          "member_statuses": {
-            "type": "array",
-            "description": "For institution identities, the list of members with their current status. Only present when `type` is `MEMBERS`.",
-            "items": {
-              "$ref": "#/components/schemas/MemberStatus"
             }
           }
         }
       },
       "RequirementError": {
         "type": "object",
-        "description": "A specific error associated with a failed or pending requirement.",
+        "description": "A specific error associated with a failed or pending requirement. For developer use only — do not expose these values directly to end users.",
         "properties": {
           "code": {
             "type": "string",
-            "description": "Machine-readable error code. Will be a fixed enum of values in the final release.",
-            "example": "submission_blurry"
+            "enum": [
+              "identity_verification_failed",
+              "document_verification_failed",
+              "screening_in_progress",
+              "screening_failed",
+              "assessment_failed",
+              "kyc_refresh_overdue",
+              "member_verification_failed",
+              "member_verification_pending",
+              "edd_documentation_required",
+              "compliance_review_required",
+              "compliance_review_failed"
+            ],
+            "description": "Machine-readable error code. Additional codes may be added in the future.",
+            "example": "identity_verification_failed"
           },
           "description": {
             "type": "string",
             "description": "Human-readable description of the error.",
-            "example": "Cannot validate ID — upload a photo of your ID that is clear"
+            "example": "Identity verification could not be completed."
           }
         }
       },
@@ -657,7 +609,7 @@
           "KYC_REFRESH",
           "MEMBERS"
         ],
-        "description": "The type of requirement.\n\n- `ID_VERIFICATION`: Government ID verification (person identities)\n- `DOCUMENT_VERIFICATION`: Business document review (institution identities)\n- `SCREENING_CHECK`: Sanctions or watchlist screening\n- `COMPLIANCE_CHECK`: Internal compliance review\n- `ENHANCED_DUE_DILIGENCE`: Enhanced due diligence review\n- `RISK_AWARENESS_ASSESSMENT`: Risk awareness assessment (person identities)\n- `KYC_REFRESH`: Periodic re-verification of identity information\n- `MEMBERS`: One or more institution members have outstanding requirements"
+        "description": "The type of requirement.\n\n- `ID_VERIFICATION`: Government ID verification (person identities)\n- `DOCUMENT_VERIFICATION`: Business document review (institution identities)\n- `SCREENING_CHECK`: Background screening check\n- `COMPLIANCE_CHECK`: Internal compliance review\n- `ENHANCED_DUE_DILIGENCE`: Enhanced due diligence review\n- `RISK_AWARENESS_ASSESSMENT`: Risk awareness assessment (person identities)\n- `KYC_REFRESH`: Periodic re-verification of identity information\n- `MEMBERS`: One or more institution members have outstanding requirements. Check `institution_members` in the response for details on which members are failing or pending"
       },
       "RequirementStatus": {
         "type": "string",
@@ -665,16 +617,15 @@
           "PENDING",
           "FAILED"
         ],
-        "description": "The status of the requirement.\n\n- `PENDING`: The requirement has not yet been fulfilled. May be under review by Paxos or a partner, or may require action from the user — check `awaiting_action_from` for details.\n- `FAILED`: The requirement was not met. May or may not require action — check `awaiting_action_from` for details."
+        "description": "The status of the requirement.\n\n- `PENDING`: The requirement has not yet been fulfilled. May be under review by Paxos or may require action from the client — check `awaiting_action_from` for details.\n- `FAILED`: The requirement was not met. May or may not require action — check `awaiting_action_from` for details."
       },
       "AwaitingActionFrom": {
         "type": "string",
         "enum": [
-          "USER",
           "PAXOS",
-          "PARTNER"
+          "CLIENT"
         ],
-        "description": "Indicates who must act to resolve the requirement.\n\n- `USER`: The end user must take action (e.g., resubmit a document)\n- `PAXOS`: Paxos is reviewing and no action is needed from the user\n- `PARTNER`: The partner (client application) must take action"
+        "description": "Indicates who must act to resolve the requirement.\n\n- `PAXOS`: Paxos is reviewing and no action is needed from the client\n- `CLIENT`: The client application must take action"
       },
       "MemberStatus": {
         "type": "object",

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -333,6 +333,9 @@
             "description": "The raw onboarding status of the identity.",
             "example": "PENDING"
           },
+          "status_details": {
+            "$ref": "#/components/schemas/IdentityStatusDetails"
+          },
           "user_disabled": {
             "type": "boolean",
             "description": "Deprecated. Whether the identity was disabled by the client. Use `status_details.active_controls` instead.",
@@ -372,9 +375,6 @@
             "type": "string",
             "description": "Aggregated TIN verification status across all tax details.",
             "example": "VALID"
-          },
-          "status_details": {
-            "$ref": "#/components/schemas/IdentityStatusDetails"
           },
           "created_at": {
             "type": "string",

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -276,12 +276,12 @@
           },
           "summary_status": {
             "allOf": [{ "$ref": "#/components/schemas/IdentitySummaryStatus" }],
-            "description": "Deprecated. Use `status` instead. The overall onboarding and compliance status of the identity. `status` and `summary_status` return the same values.",
+            "description": "Deprecated. Use `status` instead. The overall status of the identity. `status` and `summary_status` return the same values.",
             "deprecated": true
           },
           "status": {
             "type": "string",
-            "description": "The raw onboarding status of the identity.",
+            "description": "The overall status of the identity.",
             "example": "PENDING"
           },
           "status_details": {
@@ -290,11 +290,13 @@
           "user_disabled": {
             "type": "boolean",
             "description": "Deprecated. Whether the identity was disabled by the client. Use `status_details.active_controls` instead.",
+            "deprecated": true,
             "example": false
           },
           "admin_disabled": {
             "type": "boolean",
             "description": "Deprecated. Whether the identity was disabled by Paxos. Use `status_details.active_controls` instead.",
+            "deprecated": true,
             "example": false
           },
           "is_merchant": {
@@ -324,7 +326,8 @@
           },
           "summary_tin_verification_status": {
             "type": "string",
-            "description": "Aggregated TIN verification status across all tax details.",
+            "description": "Deprecated. Use `status_details.requirements` instead.",
+            "deprecated": true,
             "example": "VALID"
           },
           "created_at": {
@@ -355,7 +358,7 @@
           "DENIED",
           "DISABLED"
         ],
-        "description": "The overall onboarding and compliance status of the identity.\n\n- `PENDING`: Identity is under review\n- `APPROVED`: Identity has passed all verifications and may transact\n- `DENIED`: Identity has been denied\n- `DISABLED`: Identity has been disabled and may not transact"
+        "description": "The overall status of the identity.\n\n- `PENDING`: Identity is under review\n- `APPROVED`: Identity has passed all verifications and may transact\n- `DENIED`: Identity has been denied\n- `DISABLED`: Identity has been disabled and may not transact"
       },
       "PersonDetails": {
         "type": "object",
@@ -379,12 +382,14 @@
           },
           "id_verification_status": {
             "type": "string",
-            "description": "Status of government ID verification.",
+            "description": "Deprecated. Use `status_details.requirements` instead.",
+            "deprecated": true,
             "example": "DENIED"
           },
           "sanctions_verification_status": {
             "type": "string",
-            "description": "Status of sanctions screening.",
+            "description": "Deprecated. Use `status_details.requirements` instead.",
+            "deprecated": true,
             "example": "PENDING"
           }
         }
@@ -400,12 +405,14 @@
           },
           "sanctions_verification_status": {
             "type": "string",
-            "description": "Status of sanctions screening.",
+            "description": "Deprecated. Use `status_details.requirements` instead.",
+            "deprecated": true,
             "example": "APPROVED"
           },
           "document_verification_status": {
             "type": "string",
-            "description": "Status of document verification.",
+            "description": "Deprecated. Use `status_details.requirements` instead.",
+            "deprecated": true,
             "example": "DENIED"
           },
           "institution_type": {
@@ -525,7 +532,7 @@
       },
       "IdentityStatusDetails": {
         "type": "object",
-        "description": "Detailed breakdown of the identity's current status, including active restrictions and outstanding requirements.",
+        "description": "Detailed breakdown of the identity's current status, including active controls and outstanding requirements.",
         "properties": {
           "active_controls": {
             "type": "array",
@@ -584,7 +591,8 @@
               "member_verification_pending",
               "edd_documentation_required",
               "compliance_review_required",
-              "compliance_review_failed"
+              "compliance_review_failed",
+              "tin_not_found"
             ],
             "description": "Machine-readable error code. Additional codes may be added in the future.",
             "example": "identity_verification_failed"
@@ -606,9 +614,10 @@
           "ENHANCED_DUE_DILIGENCE",
           "RISK_AWARENESS_ASSESSMENT",
           "KYC_REFRESH",
+          "TIN_VERIFICATION",
           "MEMBERS"
         ],
-        "description": "The type of requirement.\n\n- `ID_VERIFICATION`: Government ID verification (person identities)\n- `DOCUMENT_VERIFICATION`: Business document review (institution identities)\n- `SCREENING_CHECK`: Background screening check\n- `COMPLIANCE_CHECK`: Internal compliance review\n- `ENHANCED_DUE_DILIGENCE`: Enhanced due diligence review\n- `RISK_AWARENESS_ASSESSMENT`: Risk awareness assessment (person identities)\n- `KYC_REFRESH`: Periodic re-verification of identity information\n- `MEMBERS`: One or more institution members have outstanding requirements. Check `institution_members` in the response for details on which members are failing or pending"
+        "description": "The type of requirement.\n\n- `ID_VERIFICATION`: Government ID verification (person identities)\n- `DOCUMENT_VERIFICATION`: Business document review (institution identities)\n- `SCREENING_CHECK`: Background screening check\n- `COMPLIANCE_CHECK`: Internal compliance review\n- `ENHANCED_DUE_DILIGENCE`: Enhanced due diligence review\n- `RISK_AWARENESS_ASSESSMENT`: Risk awareness assessment (person identities)\n- `KYC_REFRESH`: Periodic re-verification of identity information\n- `TIN_VERIFICATION`: Tax identification number verification\n- `MEMBERS`: One or more institution members have outstanding requirements. Check `institution_members` in the response for details on which members are failing or pending"
       },
       "RequirementStatus": {
         "type": "string",

--- a/preview/paxos-v2-preview-identity-status-details.openapi.json
+++ b/preview/paxos-v2-preview-identity-status-details.openapi.json
@@ -41,25 +41,116 @@
                   "$ref": "#/components/schemas/Identity"
                 },
                 "examples": {
-                  "pending_identity": {
-                    "summary": "Identity with pending and failed requirements",
+                  "person_denied": {
+                    "summary": "Person identity denied due to failed risk awareness assessment",
                     "value": {
-                      "id": "f190b163-208f-4d73-8deb-4fb8b24add00",
-                      "identity_type": "INSTITUTION",
-                      "summary_status": "PENDING",
-                      "created_at": "2024-01-15T10:00:00Z",
-                      "updated_at": "2024-01-15T10:30:00Z",
+                      "id": "c3d4e5f6-0000-0000-0000-000000000001",
+                      "ref_id": "user-001",
+                      "type": "PERSON",
+                      "metadata": {},
+                      "summary_status": "DENIED",
+                      "status": "DENIED",
+                      "user_disabled": false,
+                      "admin_disabled": false,
+                      "is_merchant": false,
+                      "person_details": {
+                        "first_name": "Alice",
+                        "last_name": "Johnson",
+                        "date_of_birth": "1990-05-15",
+                        "id_verification_status": "APPROVED",
+                        "sanctions_verification_status": "APPROVED"
+                      },
+                      "tax_details": [
+                        {
+                          "tax_id_type": "SSN",
+                          "tin_verification_status": "VALID"
+                        }
+                      ],
+                      "summary_tin_verification_status": "VALID",
                       "status_details": {
                         "active_controls": [],
+                        "pending_requirements": [],
+                        "failed_requirements": [
+                          {
+                            "type": "RISK_AWARENESS_ASSESSMENT",
+                            "message": "Failed PTE Risk Awareness Assessment"
+                          }
+                        ]
+                      },
+                      "created_at": "2026-03-15T08:00:00Z",
+                      "updated_at": "2026-04-05T14:30:00Z"
+                    }
+                  },
+                  "institution_pending": {
+                    "summary": "Institution identity with pending and failed requirements",
+                    "value": {
+                      "id": "f190b163-208f-4d73-8deb-4fb8b24add00",
+                      "ref_id": "acme-corp",
+                      "type": "INSTITUTION",
+                      "metadata": {
+                        "customer_ref": "acme-corp-001"
+                      },
+                      "summary_status": "PENDING",
+                      "status": "PENDING",
+                      "user_disabled": false,
+                      "admin_disabled": false,
+                      "is_merchant": false,
+                      "institution_details": {
+                        "name": "Acme Corp",
+                        "sanctions_verification_status": "APPROVED",
+                        "document_verification_status": "DENIED",
+                        "institution_type": "CORPORATION",
+                        "institution_sub_type": "PRIVATE",
+                        "business_address": {
+                          "address_line_1": "123 Main St",
+                          "city": "New York",
+                          "state": "NY",
+                          "zip": "10001",
+                          "country": "USA"
+                        },
+                        "phone_number": "+12125550100",
+                        "email": "compliance@acmecorp.com"
+                      },
+                      "institution_members": [
+                        {
+                          "id": "m1b2c3d4-0000-0000-0000-000000000001",
+                          "identity_id": "b2c3d4e5-0000-0000-0000-000000000001",
+                          "name": "Jane Smith",
+                          "roles": ["BENEFICIAL_OWNER", "CONTROL_PERSON"],
+                          "ownership": "51",
+                          "position": "CEO",
+                          "summary_status": "PENDING"
+                        },
+                        {
+                          "id": "m1b2c3d4-0000-0000-0000-000000000002",
+                          "identity_id": "a1b2c3d4-1234-5678-abcd-ef1234567890",
+                          "name": "John Doe",
+                          "roles": ["BENEFICIAL_OWNER"],
+                          "ownership": "49",
+                          "position": "CFO",
+                          "summary_status": "DISABLED"
+                        }
+                      ],
+                      "tax_details": [
+                        {
+                          "tax_id_type": "EIN",
+                          "tin_verification_status": "VALID"
+                        }
+                      ],
+                      "summary_tin_verification_status": "VALID",
+                      "status_details": {
+                        "active_controls": [
+                          {
+                            "id": "ctrl-0000-0000-0000-000000000001",
+                            "type": "SELL_ONLY",
+                            "set_by": "SET_BY_PAXOS",
+                            "is_overridable": false,
+                            "reason_code": "COMPLIANCE_KYC",
+                            "reason": "Identity pending full KYC review",
+                            "created_at": "2026-03-01T10:00:00Z"
+                          }
+                        ],
                         "pending_requirements": [
-                          {
-                            "type": "ID_VERIFICATION",
-                            "message": "Pending ID Verification"
-                          },
-                          {
-                            "type": "DOCUMENT_VERIFICATION",
-                            "message": "Pending document verification"
-                          },
                           {
                             "type": "COMPLIANCE_CHECK",
                             "message": "Pending compliance check"
@@ -69,7 +160,7 @@
                             "message": "Pending members",
                             "member_list": [
                               {
-                                "identity_id": "f190b163-208f-4d73-8deb-4fb8b24add00",
+                                "identity_id": "b2c3d4e5-0000-0000-0000-000000000001",
                                 "summary_status": "PENDING"
                               }
                             ]
@@ -81,12 +172,8 @@
                             "message": "Failed document verification"
                           },
                           {
-                            "type": "COMPLIANCE_CHECK",
-                            "message": "Failed compliance check"
-                          },
-                          {
                             "type": "MEMBERS",
-                            "message": "Disabled members",
+                            "message": "Failed members",
                             "member_list": [
                               {
                                 "identity_id": "a1b2c3d4-1234-5678-abcd-ef1234567890",
@@ -95,32 +182,9 @@
                             ]
                           }
                         ]
-                      }
-                    }
-                  },
-                  "approved_identity": {
-                    "summary": "Approved identity with active control",
-                    "value": {
-                      "id": "a1b2c3d4-1234-5678-abcd-ef1234567890",
-                      "identity_type": "INDIVIDUAL",
-                      "summary_status": "APPROVED",
-                      "created_at": "2024-01-10T09:00:00Z",
-                      "updated_at": "2024-01-10T09:15:00Z",
-                      "status_details": {
-                        "active_controls": [
-                          {
-                            "id": "59b8e3c5-2b6e-4fa6-afcf-8c685598241d",
-                            "type": "SELL_ONLY",
-                            "set_by": "SET_BY_CLIENT",
-                            "is_overridable": true,
-                            "reason_code": "END_USER_REQUEST",
-                            "reason": "User requested sell-only mode",
-                            "created_at": "2024-01-10T09:15:00Z"
-                          }
-                        ],
-                        "pending_requirements": [],
-                        "failed_requirements": []
-                      }
+                      },
+                      "created_at": "2026-03-01T09:00:00Z",
+                      "updated_at": "2026-04-01T12:00:00Z"
                     }
                   }
                 }
@@ -166,11 +230,69 @@
             "description": "Unique identifier for the identity.",
             "example": "f190b163-208f-4d73-8deb-4fb8b24add00"
           },
-          "identity_type": {
+          "ref_id": {
+            "type": "string",
+            "description": "Client-provided reference ID for the identity.",
+            "example": "acme-corp"
+          },
+          "type": {
             "$ref": "#/components/schemas/IdentityType"
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Arbitrary key-value metadata associated with the identity.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "example": { "customer_ref": "acme-corp-001" }
           },
           "summary_status": {
             "$ref": "#/components/schemas/IdentitySummaryStatus"
+          },
+          "status": {
+            "type": "string",
+            "description": "The raw onboarding status of the identity.",
+            "example": "PENDING"
+          },
+          "user_disabled": {
+            "type": "boolean",
+            "description": "Deprecated. Whether the identity was disabled by the client. Use `status_details.active_controls` instead.",
+            "example": false
+          },
+          "admin_disabled": {
+            "type": "boolean",
+            "description": "Deprecated. Whether the identity was disabled by Paxos. Use `status_details.active_controls` instead.",
+            "example": false
+          },
+          "is_merchant": {
+            "type": "boolean",
+            "description": "Whether this identity is a merchant.",
+            "example": false
+          },
+          "institution_details": {
+            "$ref": "#/components/schemas/InstitutionDetails"
+          },
+          "person_details": {
+            "$ref": "#/components/schemas/PersonDetails"
+          },
+          "institution_members": {
+            "type": "array",
+            "description": "Members of the institution (beneficial owners, control persons, etc.).",
+            "items": {
+              "$ref": "#/components/schemas/InstitutionMember"
+            }
+          },
+          "tax_details": {
+            "type": "array",
+            "description": "Tax identification details for the identity.",
+            "items": {
+              "$ref": "#/components/schemas/TaxDetail"
+            }
+          },
+          "summary_tin_verification_status": {
+            "type": "string",
+            "description": "Aggregated TIN verification status across all tax details.",
+            "example": "VALID"
           },
           "status_details": {
             "$ref": "#/components/schemas/IdentityStatusDetails"
@@ -191,9 +313,10 @@
         "type": "string",
         "enum": [
           "INDIVIDUAL",
-          "INSTITUTION"
+          "INSTITUTION",
+          "PERSON"
         ],
-        "description": "The type of identity.\n\n- `INDIVIDUAL`: A natural person\n- `INSTITUTION`: A legal entity or business"
+        "description": "The type of identity.\n\n- `INDIVIDUAL`: A natural person\n- `INSTITUTION`: A legal entity or business\n- `PERSON`: A person associated with an institution (e.g., beneficial owner or control person)"
       },
       "IdentitySummaryStatus": {
         "type": "string",
@@ -204,6 +327,171 @@
           "DISABLED"
         ],
         "description": "The overall onboarding and compliance status of the identity.\n\n- `PENDING`: Identity is under review\n- `APPROVED`: Identity has passed all verifications and may transact\n- `DENIED`: Identity has been denied\n- `DISABLED`: Identity has been disabled and may not transact"
+      },
+      "PersonDetails": {
+        "type": "object",
+        "description": "Details specific to person identities.",
+        "properties": {
+          "first_name": {
+            "type": "string",
+            "description": "First name of the person.",
+            "example": "Alice"
+          },
+          "last_name": {
+            "type": "string",
+            "description": "Last name of the person.",
+            "example": "Johnson"
+          },
+          "date_of_birth": {
+            "type": "string",
+            "format": "date",
+            "description": "Date of birth in YYYY-MM-DD format.",
+            "example": "1990-05-15"
+          },
+          "id_verification_status": {
+            "type": "string",
+            "description": "Status of government ID verification.",
+            "example": "APPROVED"
+          },
+          "sanctions_verification_status": {
+            "type": "string",
+            "description": "Status of sanctions screening.",
+            "example": "APPROVED"
+          }
+        }
+      },
+      "InstitutionDetails": {
+        "type": "object",
+        "description": "Details specific to institution identities.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Legal name of the institution.",
+            "example": "Acme Corp"
+          },
+          "sanctions_verification_status": {
+            "type": "string",
+            "description": "Status of sanctions screening.",
+            "example": "APPROVED"
+          },
+          "document_verification_status": {
+            "type": "string",
+            "description": "Status of document verification.",
+            "example": "DENIED"
+          },
+          "institution_type": {
+            "type": "string",
+            "description": "The legal type of the institution.",
+            "example": "CORPORATION"
+          },
+          "institution_sub_type": {
+            "type": "string",
+            "description": "The sub-type of the institution.",
+            "example": "PRIVATE"
+          },
+          "business_address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "phone_number": {
+            "type": "string",
+            "description": "Contact phone number.",
+            "example": "+12125550100"
+          },
+          "email": {
+            "type": "string",
+            "description": "Contact email address.",
+            "example": "compliance@acmecorp.com"
+          }
+        }
+      },
+      "Address": {
+        "type": "object",
+        "description": "A physical address.",
+        "properties": {
+          "address_line_1": {
+            "type": "string",
+            "example": "123 Main St"
+          },
+          "address_line_2": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string",
+            "example": "New York"
+          },
+          "state": {
+            "type": "string",
+            "example": "NY"
+          },
+          "zip": {
+            "type": "string",
+            "example": "10001"
+          },
+          "country": {
+            "type": "string",
+            "example": "USA"
+          }
+        }
+      },
+      "InstitutionMember": {
+        "type": "object",
+        "description": "A member of an institution identity.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the membership record.",
+            "example": "m1b2c3d4-0000-0000-0000-000000000001"
+          },
+          "identity_id": {
+            "type": "string",
+            "description": "The identity ID of the member.",
+            "example": "b2c3d4e5-0000-0000-0000-000000000001"
+          },
+          "name": {
+            "type": "string",
+            "description": "Full name of the member.",
+            "example": "Jane Smith"
+          },
+          "roles": {
+            "type": "array",
+            "description": "Roles held by the member within the institution.",
+            "items": {
+              "type": "string"
+            },
+            "example": ["BENEFICIAL_OWNER", "CONTROL_PERSON"]
+          },
+          "ownership": {
+            "type": "string",
+            "description": "Ownership percentage as a string.",
+            "example": "51"
+          },
+          "position": {
+            "type": "string",
+            "description": "Job title or position within the institution.",
+            "example": "CEO"
+          },
+          "summary_status": {
+            "type": "string",
+            "description": "The summary status of the member's identity.",
+            "example": "PENDING"
+          }
+        }
+      },
+      "TaxDetail": {
+        "type": "object",
+        "description": "Tax identification detail for an identity.",
+        "properties": {
+          "tax_id_type": {
+            "type": "string",
+            "description": "The type of tax identifier (e.g., `EIN`, `SSN`).",
+            "example": "EIN"
+          },
+          "tin_verification_status": {
+            "type": "string",
+            "description": "Verification status of the TIN.",
+            "example": "VALID"
+          }
+        }
       },
       "IdentityStatusDetails": {
         "type": "object",
@@ -243,7 +531,7 @@
           "message": {
             "type": "string",
             "description": "Human-readable description of the pending requirement.",
-            "example": "Pending ID Verification"
+            "example": "Pending compliance check"
           },
           "member_list": {
             "type": "array",
@@ -292,9 +580,10 @@
           "ID_VERIFICATION",
           "DOCUMENT_VERIFICATION",
           "COMPLIANCE_CHECK",
-          "MEMBERS"
+          "MEMBERS",
+          "RISK_AWARENESS_ASSESSMENT"
         ],
-        "description": "The type of failed requirement.\n\n- `ID_VERIFICATION`: Identity verification failed\n- `DOCUMENT_VERIFICATION`: Document verification failed\n- `COMPLIANCE_CHECK`: Compliance check failed\n- `MEMBERS`: One or more institution members have a failed status (e.g., disabled, denied, or error)"
+        "description": "The type of failed requirement.\n\n- `ID_VERIFICATION`: Identity verification failed\n- `DOCUMENT_VERIFICATION`: Document verification failed\n- `COMPLIANCE_CHECK`: Compliance check failed\n- `MEMBERS`: One or more institution members have a failed status (e.g., disabled, denied, or error)\n- `RISK_AWARENESS_ASSESSMENT`: Risk awareness assessment failed"
       },
       "MemberStatus": {
         "type": "object",
@@ -303,7 +592,7 @@
           "identity_id": {
             "type": "string",
             "description": "The identity ID of the member.",
-            "example": "f190b163-208f-4d73-8deb-4fb8b24add00"
+            "example": "b2c3d4e5-0000-0000-0000-000000000001"
           },
           "summary_status": {
             "type": "string",


### PR DESCRIPTION
## Summary
Adds a developer preview API reference page for the upcoming `status_details` changes to the GetIdentity endpoint, including the new `pending_requirements` and `failed_requirements` fields.

## Changes
- **New OpenAPI spec** (`preview/paxos-v2-preview-identity-status-details.openapi.json`): Defines `GET /v2/identity/identities/{id}` with the updated `IdentityStatusDetails` schema — `active_controls` (existing), `pending_requirements`, and `failed_requirements`
- **New preview page** (`preview/get-identity.mdx`): API reference page with field descriptions and type tables for the new `pending_requirements` types (`ID_VERIFICATION`, `DOCUMENT_VERIFICATION`, `COMPLIANCE_CHECK`, `MEMBERS`) and `failed_requirements` types (`ID_VERIFICATION`, `DOCUMENT_VERIFICATION`, `COMPLIANCE_CHECK`, `MEMBERS`)
- **Navigation** (`docs.json`): Adds an Identity group under the hidden Previews tab pointing to the new page

## Tests
- **Manual testing**: Run `mintlify dev` and navigate to the Previews > Identity > Get Identity page to verify the API reference renders correctly with example responses

Ticket: https://paxos.atlassian.net/browse/RP-5021