### PR TITLE
STAX-2462 Rename Order Routing to Smart Order Routing

### DIFF
--- a/api-reference/websockets/overview.mdx
+++ b/api-reference/websockets/overview.mdx
@@ -14,10 +14,10 @@ Paxos offers two WebSocket API solutions for different use cases:
 ### Public WebSocket API
 Open access to real-time market and execution data feeds via public [WebSocket](https://websocket.spec.whatwg.org) connections. Ideal for DMA (Direct Market Access) to itBit and general market data consumption. No authentication required.
 
-### Order Routing WebSocket API  
-Authenticated, bidirectional WebSocket API exclusively for Order Routing platform customers. Provides request-response operations and streaming data with OAuth2 authentication. [Learn more](/api-reference/websockets/order-routing-overview).
+### Smart Order Routing WebSocket API  
+Authenticated, bidirectional WebSocket API exclusively for Smart Order Routing platform customers. Provides request-response operations and streaming data with OAuth2 authentication. [Learn more](/api-reference/websockets/smart-order-routing-overview).
 
-> Order Routing customers should use the authenticated [Order Routing WebSocket API](/api-reference/websockets/order-routing-overview) for enhanced functionality and authorized access.
+> Smart Order Routing customers should use the authenticated [Smart Order Routing WebSocket API](/api-reference/websockets/smart-order-routing-overview) for enhanced functionality and authorized access.
 
 ## Public WebSocket API
 

--- a/api-reference/websockets/smart-order-routing-execution-data.mdx
+++ b/api-reference/websockets/smart-order-routing-execution-data.mdx
@@ -1,13 +1,13 @@
 ---
-title: Order Routing Execution Data
-description: Real-time trade execution information for Order Routing platform.
+title: Smart Order Routing Execution Data
+description: Real-time trade execution information for Smart Order Routing platform.
 tags:
-  - Order Routing
+  - Smart Order Routing
   - Execution Data
   - WebSocket
 ---
 
-The Execution Data channel provides real-time trade execution information for authorized Order Routing customers. Subscribe to receive notifications as trades execute on the platform.
+The Execution Data channel provides real-time trade execution information for authorized Smart Order Routing customers. Subscribe to receive notifications as trades execute on the platform.
 
 ## Subscribe to Execution Data
 

--- a/api-reference/websockets/smart-order-routing-heartbeat.mdx
+++ b/api-reference/websockets/smart-order-routing-heartbeat.mdx
@@ -1,13 +1,13 @@
 ---
-title: Order Routing Heartbeat
-description: Logical-level liveness signal for Order Routing platform.
+title: Smart Order Routing Heartbeat
+description: Logical-level liveness signal for Smart Order Routing platform.
 tags:
-  - Order Routing
+  - Smart Order Routing
   - Heartbeat
   - WebSocket
 ---
 
-The Heartbeat channel provides a logical-level liveness signal for authorized Order Routing customers. Subscribe to receive periodic heartbeat messages to monitor the health of your WebSocket connection and the server's responsiveness.
+The Heartbeat channel provides a logical-level liveness signal for authorized Smart Order Routing customers. Subscribe to receive periodic heartbeat messages to monitor the health of your WebSocket connection and the server's responsiveness.
 
 ## Subscribe to Heartbeat
 

--- a/api-reference/websockets/smart-order-routing-market-data.mdx
+++ b/api-reference/websockets/smart-order-routing-market-data.mdx
@@ -1,13 +1,13 @@
 ---
-title: Order Routing Market Data
-description: Real-time order book updates for Order Routing platform.
+title: Smart Order Routing Market Data
+description: Real-time order book updates for Smart Order Routing platform.
 tags:
-  - Order Routing
+  - Smart Order Routing
   - Market Data
   - WebSocket
 ---
 
-The Market Data channel provides real-time order book updates for authorized Order Routing customers. Subscribe to receive full order book snapshots followed by incremental updates.
+The Market Data channel provides real-time order book updates for authorized Smart Order Routing customers. Subscribe to receive full order book snapshots followed by incremental updates.
 
 ## Subscribe to Market Data
 

--- a/api-reference/websockets/smart-order-routing-overview.mdx
+++ b/api-reference/websockets/smart-order-routing-overview.mdx
@@ -1,15 +1,15 @@
 ---
-title: Order Routing WebSocket API
-description: Authenticated real-time market data for Order Routing platform customers.
+title: Smart Order Routing WebSocket API
+description: Authenticated real-time market data for Smart Order Routing platform customers.
 tags:
-  - Order Routing
+  - Smart Order Routing
   - WebSocket
   - Market Data
 ---
 
-The Order Routing WebSocket API provides authenticated, real-time streaming market data and execution data to authorized Order Routing platform customers. This API uses a bidirectional WebSocket connection for both request-response operations and streaming data delivery.
+The Smart Order Routing WebSocket API provides authenticated, real-time streaming market data and execution data to authorized Smart Order Routing platform customers. This API uses a bidirectional WebSocket connection for both request-response operations and streaming data delivery.
 
-> This API is available only to Order Routing customers on the allow list. For public market data access or DMA (Direct Market Access) to itBit, use the [public WebSocket API](/api-reference/websockets/overview).
+> This API is available only to Smart Order Routing customers on the allow list. For public market data access or DMA (Direct Market Access) to itBit, use the [public WebSocket API](/api-reference/websockets/overview).
 
 ## Connection
 
@@ -228,7 +228,7 @@ Get all active subscriptions for your connection.
 
 ## Data Channels
 
-The Order Routing WebSocket API supports four types of streaming data channels:
+The Smart Order Routing WebSocket API supports four types of streaming data channels:
 
 ### Market Data Channel
 Provides real-time order book updates with initial snapshots and incremental changes.
@@ -236,7 +236,7 @@ Provides real-time order book updates with initial snapshots and incremental cha
 - **Channel type:** `market_data`
 - **Initial message:** Full order book snapshot
 - **Subsequent messages:** Incremental updates
-- **[View detailed documentation →](/api-reference/websockets/order-routing-market-data)**
+- **[View detailed documentation →](/api-reference/websockets/smart-order-routing-market-data)**
 
 **Example streaming message:**
 ```json
@@ -258,7 +258,7 @@ Provides real-time updates of the best bid and best ask prices only.
 - **Channel type:** `market_data.top_of_book`
 - **Message frequency:** On best price changes
 - **Lightweight alternative to full order book**
-- **[View detailed documentation →](/api-reference/websockets/order-routing-top-of-book)**
+- **[View detailed documentation →](/api-reference/websockets/smart-order-routing-top-of-book)**
 
 **Example streaming message:**
 ```json
@@ -279,7 +279,7 @@ Provides real-time trade execution notifications.
 
 - **Channel type:** `execution_data`
 - **Message frequency:** On each trade execution
-- **[View detailed documentation →](/api-reference/websockets/order-routing-execution-data)**
+- **[View detailed documentation →](/api-reference/websockets/smart-order-routing-execution-data)**
 
 **Example streaming message:**
 ```json
@@ -300,7 +300,7 @@ Provides logical-level liveness signal for connection monitoring.
 - **Channel type:** `heartbeat`
 - **Message frequency:** Periodic heartbeat messages
 - **No parameters required**
-- **[View detailed documentation →](/api-reference/websockets/order-routing-heartbeat)**
+- **[View detailed documentation →](/api-reference/websockets/smart-order-routing-heartbeat)**
 
 **Example streaming message:**
 ```json

--- a/api-reference/websockets/smart-order-routing-top-of-book.mdx
+++ b/api-reference/websockets/smart-order-routing-top-of-book.mdx
@@ -1,13 +1,13 @@
 ---
-title: Order Routing Top of Book
-description: Real-time best bid and ask updates for Order Routing platform.
+title: Smart Order Routing Top of Book
+description: Real-time best bid and ask updates for Smart Order Routing platform.
 tags:
-  - Order Routing
+  - Smart Order Routing
   - Market Data
   - WebSocket
 ---
 
-The Top of Book channel provides real-time updates of the best bid and best ask prices for authorized Order Routing customers. This lightweight channel is ideal when you only need the best available prices without the full order book depth.
+The Top of Book channel provides real-time updates of the best bid and best ask prices for authorized Smart Order Routing customers. This lightweight channel is ideal when you only need the best available prices without the full order book depth.
 
 ## Subscribe to Top of Book
 

--- a/docs.json
+++ b/docs.json
@@ -244,7 +244,7 @@
                 ]
               },
               "guides/crypto-brokerage/websocket",
-              "guides/crypto-brokerage/order-routing-websocket",
+              "guides/crypto-brokerage/smart-order-routing-websocket",
               "guides/crypto-brokerage/orders-precision-rounding",
               "guides/crypto-brokerage/commissions-rebates",
               "guides/crypto-brokerage/ledger-type",
@@ -862,13 +862,13 @@
                 ]
               },
               {
-                "group": "Order Routing WebSocket API",
+                "group": "Smart Order Routing WebSocket API",
                 "pages": [
-                  "api-reference/websockets/order-routing-overview",
-                  "api-reference/websockets/order-routing-market-data",
-                  "api-reference/websockets/order-routing-top-of-book",
-                  "api-reference/websockets/order-routing-execution-data",
-                  "api-reference/websockets/order-routing-heartbeat"
+                  "api-reference/websockets/smart-order-routing-overview",
+                  "api-reference/websockets/smart-order-routing-market-data",
+                  "api-reference/websockets/smart-order-routing-top-of-book",
+                  "api-reference/websockets/smart-order-routing-execution-data",
+                  "api-reference/websockets/smart-order-routing-heartbeat"
                 ]
               }
             ]

--- a/guides/crypto-brokerage/smart-order-routing-websocket.mdx
+++ b/guides/crypto-brokerage/smart-order-routing-websocket.mdx
@@ -1,11 +1,11 @@
 ---
-title: Order Routing WebSocket Integration
-description: Step-by-step guide to integrate with the Order Routing WebSocket API.
+title: Smart Order Routing WebSocket Integration
+description: Step-by-step guide to integrate with the Smart Order Routing WebSocket API.
 ---
 
-This guide walks you through integrating with the Paxos Order Routing WebSocket API to receive real-time market data and execution updates. The Order Routing WebSocket API requires authentication and is available only to authorized Order Routing platform customers.
+This guide walks you through integrating with the Paxos Smart Order Routing WebSocket API to receive real-time market data and execution updates. The Smart Order Routing WebSocket API requires authentication and is available only to authorized Smart Order Routing platform customers.
 
-> Before starting, ensure you have Order Routing platform access and valid OAuth2 credentials with the `exchange:read_aggregated_marketdata_stream` scope.
+> Before starting, ensure you have Smart Order Routing platform access and valid OAuth2 credentials with the `exchange:read_aggregated_marketdata_stream` scope.
 
 ## ➊ Authenticate and Get Access Token
 
@@ -39,7 +39,7 @@ const ws = new WebSocket('wss://ws.sandbox.paxos.com/', {
 });
 
 ws.on('open', () => {
-  console.log('Connected to Order Routing WebSocket');
+  console.log('Connected to Smart Order Routing WebSocket');
 });
 
 ws.on('message', (data) => {
@@ -70,7 +70,7 @@ async def connect_websocket():
     }
     
     async with websockets.connect(uri, extra_headers=headers) as websocket:
-        print('Connected to Order Routing WebSocket')
+        print('Connected to Smart Order Routing WebSocket')
         
         # Handle incoming messages
         async for message in websocket:
@@ -293,7 +293,7 @@ class OrderRoutingWebSocket {
     });
 
     this.ws.on('open', () => {
-      console.log('Connected to Order Routing WebSocket');
+      console.log('Connected to Smart Order Routing WebSocket');
       this.subscribeToMarkets(['BTCUSD', 'ETHUSD']);
     });
 
@@ -477,6 +477,6 @@ ws.on('message', (data) => {
 
 ## Next Steps
 
-- Review the [Order Routing Market Data](/api-reference/websockets/order-routing-market-data) reference
-- Explore the [Order Routing Execution Data](/api-reference/websockets/order-routing-execution-data) reference
+- Review the [Smart Order Routing Market Data](/api-reference/websockets/smart-order-routing-market-data) reference
+- Explore the [Smart Order Routing Execution Data](/api-reference/websockets/smart-order-routing-execution-data) reference
 - Contact [Support](https://support.paxos.com) for production access

--- a/guides/developer/api-websocket.mdx
+++ b/guides/developer/api-websocket.mdx
@@ -10,10 +10,10 @@ Paxos offers two WebSocket API solutions:
 ### Public WebSocket API
 Provides secure, real-time market and execution data feeds via public [WebSocket](https://websocket.spec.whatwg.org) connections. No authentication required. Ideal for DMA to itBit and general market data consumption.
 
-### Order Routing WebSocket API
-Authenticated, bidirectional WebSocket API for Order Routing platform customers. Requires OAuth2 authentication with the `exchange:read_aggregated_marketdata_stream` scope. [Learn more](/api-reference/websockets/order-routing-overview).
+### Smart Order Routing WebSocket API
+Authenticated, bidirectional WebSocket API for Smart Order Routing platform customers. Requires OAuth2 authentication with the `exchange:read_aggregated_marketdata_stream` scope. [Learn more](/api-reference/websockets/smart-order-routing-overview).
 
-> Order Routing customers should use the [Order Routing WebSocket API](/guides/crypto-brokerage/order-routing-websocket) for enhanced functionality.
+> Smart Order Routing customers should use the [Smart Order Routing WebSocket API](/guides/crypto-brokerage/smart-order-routing-websocket) for enhanced functionality.
 
 ## Public WebSocket Feeds
 


### PR DESCRIPTION
## Summary
- Rename all prose references from "Order Routing" to "Smart Order Routing" across documentation
- Rename 6 files from `order-routing-*` to `smart-order-routing-*`
- Update all internal links, sidebar navigation (`docs.json`), and cross-references to match new file paths
- FIX protocol field names (`OrderRoutingMode`, `OrderRoutingWebSocket`) are intentionally kept unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)