### PR TITLE
DOCS-1332: Add changelog entry for List Markets market status

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -11,6 +11,18 @@ rss: true
 - [Rewards](/api-reference/endpoints/reward-details/overview): Retrieve a breakdown of earned rewards by type and time period.
 </Update>
 
+<Update label="April 20, 2026" description="v2 API">
+**List Markets: Market Status**: The [List Markets](/api-reference/endpoints/market-data/list-markets) endpoint now returns a `market_status` field on each market, providing real-time trading availability, reason codes, and scheduled maintenance windows.
+
+The `market_status` object includes:
+- `buy_status` / `sell_status` — Trading availability: `AVAILABLE` or `UNAVAILABLE`
+- `buy_reason` / `sell_reason` — Reason a side is unavailable: `SCHEDULED_MAINTENANCE`, `TRADING_SUSPENDED`, or `UNSCHEDULED_MAINTENANCE`
+- `updated_at` — Timestamp of the most recent status update
+- `scheduled_maintenance` — Array of upcoming maintenance windows, each with `starts_at`, `ends_at`, and `recurrence` (`NONE`, `DAILY`, `WEEKLY`)
+
+A market reports `AVAILABLE` when at least one venue is healthy. It becomes `UNAVAILABLE` when all venues are down, surfacing the most severe reason code.
+</Update>
+
 <Update label="April 1, 2026" description="v2 API">
 **List Orchestrations**: Added `ref_id` query parameter to the [List Orchestrations](/api-reference/endpoints/orchestration/list-orchestrations) endpoint. Use this repeated parameter to filter orchestrations by client-provided idempotency key.
 </Update>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -3,14 +3,6 @@ title: "Changelog"
 description: "Product updates and announcements"
 rss: true
 ---
-<Update label="March 30, 2026" description="v2 API">
-**Rewards Engine API (Preview)**: Added new Rewards Engine API endpoints, currently in **Preview** and available to selected partners. The following endpoint groups are now available:
-- [Reward Addresses](/api-reference/endpoints/reward-addresses/overview): Register and manage blockchain addresses that receive reward payouts.
-- [Claims](/api-reference/endpoints/claims/overview): Create and manage claim schedules to automate reward distributions, and view individual claim events.
-- [Payout Groups](/api-reference/endpoints/payout-groups/overview): Configure groups of addresses to receive proportional shares of reward payments.
-- [Rewards](/api-reference/endpoints/reward-details/overview): Retrieve a breakdown of earned rewards by type and time period.
-</Update>
-
 <Update label="April 20, 2026" description="v2 API">
 **List Markets: Market Status**: The [List Markets](/api-reference/endpoints/market-data/list-markets) endpoint now returns a `market_status` field on each market, providing real-time trading availability, reason codes, and scheduled maintenance windows.
 
@@ -25,6 +17,14 @@ A market reports `AVAILABLE` when at least one venue is healthy. It becomes `UNA
 
 <Update label="April 1, 2026" description="v2 API">
 **List Orchestrations**: Added `ref_id` query parameter to the [List Orchestrations](/api-reference/endpoints/orchestration/list-orchestrations) endpoint. Use this repeated parameter to filter orchestrations by client-provided idempotency key.
+</Update>
+
+<Update label="March 30, 2026" description="v2 API">
+**Rewards Engine API (Preview)**: Added new Rewards Engine API endpoints, currently in **Preview** and available to selected partners. The following endpoint groups are now available:
+- [Reward Addresses](/api-reference/endpoints/reward-addresses/overview): Register and manage blockchain addresses that receive reward payouts.
+- [Claims](/api-reference/endpoints/claims/overview): Create and manage claim schedules to automate reward distributions, and view individual claim events.
+- [Payout Groups](/api-reference/endpoints/payout-groups/overview): Configure groups of addresses to receive proportional shares of reward payments.
+- [Rewards](/api-reference/endpoints/reward-details/overview): Retrieve a breakdown of earned rewards by type and time period.
 </Update>
 
 <Update label="March 23, 2026" description="v2 API">


### PR DESCRIPTION
## Summary
- Adds changelog entry (April 20, 2026) announcing the new `market_status` field on the [List Markets](https://docs.paxos.com/api-reference/endpoints/market-data/list-markets) endpoint
- Documents trading availability (`buy_status`/`sell_status`), reason codes, and scheduled maintenance windows

## References
- Jira: [DOCS-1332](https://itbitwiki.atlassian.net/browse/DOCS-1332)
- Backend PR: [paxosglobal/pax#53714](https://github.com/paxosglobal/pax/pull/53714)
- Related: [STAX-2511](https://itbitwiki.atlassian.net/browse/STAX-2511)

## Test plan
- [ ] Verify changelog entry renders correctly on the docs site
- [ ] Confirm April 20, 2026 date and ordering relative to neighboring entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-1332]: https://itbitwiki.atlassian.net/browse/DOCS-1332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STAX-2511]: https://itbitwiki.atlassian.net/browse/STAX-2511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<img width="859" height="718" alt="Screenshot 2026-04-15 at 4 47 43 PM" src="https://github.com/user-attachments/assets/eb8c8e5d-57df-456a-a733-9eaeefa378d6" />


