### PR TITLE
DOCS-000 Add note clarifying Approvals apply to Dashboard UI only, not API

### DIFF
--- a/guides/dashboard/admin/approvals.mdx
+++ b/guides/dashboard/admin/approvals.mdx
@@ -31,7 +31,7 @@ Paxos is working on rolling out approvals for additional actions and more custom
 </Note>
 
 <Note>
-Approvals apply to actions taken in the Paxos Dashboard only. Actions submitted via the API are not affected by approval policies.
+Approvals only apply to actions in the Paxos Dashboard. API-submitted actions and transactions are not affected.
 </Note>
 
 ## Why Approvals Matter

--- a/guides/dashboard/admin/approvals.mdx
+++ b/guides/dashboard/admin/approvals.mdx
@@ -30,6 +30,10 @@ Approvals are currently available for:
 Paxos is working on rolling out approvals for additional actions and more customization options for approval policies.
 </Note>
 
+<Note>
+Approvals apply to actions taken in the Paxos Dashboard only. Actions submitted via the API are not affected by approval policies.
+</Note>
+
 ## Why Approvals Matter
 
 Approvals helps your organization:


### PR DESCRIPTION
## Summary
- Adds a `<Note>` callout above the "Why Approvals Matter" section on the Approvals guide
- Clarifies that approval policies apply to Dashboard UI actions only and do not affect API submissions

## Test plan
- [ ] Verify note renders correctly on the Approvals page below the existing rollout note
- [ ] Confirm wording matches the page's style and tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="860" height="822" alt="Screenshot 2026-04-17 at 10 24 59 AM" src="https://github.com/user-attachments/assets/bc5c1a8d-05ce-4623-996d-e35599510767" />

