### PR TITLE
ISS-201: Update payout group field descriptions to reflect on-chain semantics

### DIFF
--- a/preview/paxos-v2-preview-rewards.openapi.json
+++ b/preview/paxos-v2-preview-rewards.openapi.json
@@ -834,9 +834,9 @@
           "rate_id": { "type": "string", "description": "Rate ID associated with this payout group." },
           "jurisdiction": { "type": "string", "description": "Jurisdiction for this payout group." },
           "name": { "type": "string", "description": "User-readable name for this group." },
-          "claimer_address": { "type": "string", "description": "Address that will claim rewards for this group." },
-          "manager_address": { "type": "string", "description": "Address that manages this payout group (optional)." },
-          "destination_address": { "type": "string", "description": "Address that will receive payouts from this group (optional)." },
+          "claimer_address": { "type": "string", "description": "Address with signing authority to claim rewards for this group." },
+          "manager_address": { "type": "string", "description": "Address that manages this payout group. Defaults to claimer_address if not explicitly set." },
+          "destination_address": { "type": "string", "description": "Address that receives reward payouts for this group. Defaults to claimer_address if not explicitly set." },
           "onchain_group_id": { "type": "string", "format": "int64", "description": "On-chain group ID (optional)." },
           "onchain_status": { "type": "string", "description": "Status of the on-chain group." },
           "balance": { "type": "string", "description": "Current balance of unclaimed rewards." },
@@ -865,7 +865,7 @@
           "asset_type": { "type": "string", "description": "Asset type for this payout group." },
           "jurisdiction": { "type": "string", "description": "Jurisdiction for this payout group." },
           "name": { "type": "string", "description": "User-readable name for this group." },
-          "claimer_address": { "type": "string", "description": "Address that will claim rewards for this group." },
+          "claimer_address": { "type": "string", "description": "Address with signing authority to claim rewards for this group." },
           "schedule_type": { "$ref": "#/components/schemas/ScheduleType" }
         }
       },


### PR DESCRIPTION
## Summary

Update `claimer_address`, `manager_address`, and `destination_address` field descriptions in the Rewards (Alpha) OpenAPI spec to accurately reflect on-chain behavior, addressing customer confusion reported in the ISS-201 Slack thread.

## Changes

- **`claimer_address`**: "Address that will claim rewards for this group." → "Address with signing authority to claim rewards for this group." (applies to both `PayoutGroup` and `CreatePayoutGroupRequest`)
- **`manager_address`**: "Address that manages this payout group (optional)." → "Address that manages this payout group. Defaults to claimer_address if not explicitly set."
- **`destination_address`**: "Address that will receive payouts from this group (optional)." → "Address that receives reward payouts for this group. Defaults to claimer_address if not explicitly set."

These descriptions now match the proto/OpenAPI changes shipped in [paxosglobal/pax#54362](https://github.com/paxosglobal/pax/pull/54362).

## Test plan

- [ ] Verify payout group endpoint pages in the Rewards (Alpha) section render the updated field descriptions correctly
- [ ] Confirm `manager_address` and `destination_address` descriptions no longer say "(optional)" — the default behavior is now explicit

Ticket: https://itbitwiki.atlassian.net/browse/ISS-201