### PR TITLE
STAX-2074 STAX-2221 STAX-2817 Add Batch 1 and 2, and DOGE assets to Trading and Custody

### DIFF
--- a/guides/developer/blockchains.mdx
+++ b/guides/developer/blockchains.mdx
@@ -13,44 +13,56 @@ These assets are supported in the context of three main use cases:
 
 ## Stablecoins
 
-| Stablecoin                                                | Arbitrum One | Base | Ethereum | Ink | Polygon PoS | Solana | Stellar | X Layer |
-|-----------------------------------------------------------| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| Binance USD ([BUSD](/guides/stablecoin/busd))<sup>1</sup> | -- | -- | ✅ | -- | -- | -- | -- | -- |
-| Global Dollar ([USDG](/guides/stablecoin/usdg))           | -- | -- | ✅ | ✅ | -- | ✅ | -- | ✅ |
-| Pax Dollar ([USDP](/guides/stablecoin/usdp))              | -- | -- | ✅ | -- | -- | ✅ | -- | -- |
-| PayPal USD ([PYUSD](/guides/stablecoin/pyusd))            | ✅ | -- | ✅ | -- | -- | ✅ | ✅ | -- |
-| USD Coin (USDC)                                           | -- | ✅ | ✅ | -- | ✅ | ✅ | -- | -- |
+| Stablecoin | Ticker | Network |
+| --- | --- | --- |
+| Binance USD | BUSD<sup>1</sup> | Ethereum |
+| Global Dollar | USDG | Ethereum |
+| Global Dollar | USDG | Ink |
+| Global Dollar | USDG | Solana |
+| Global Dollar | USDG | X Layer |
+| Pax Dollar | USDP | Ethereum |
+| Pax Dollar | USDP | Solana |
+| PayPal USD | PYUSD | Arbitrum One |
+| PayPal USD | PYUSD | Ethereum |
+| PayPal USD | PYUSD | Solana |
+| PayPal USD | PYUSD | Stellar |
+| USD Coin | USDC | Base |
+| USD Coin | USDC | Ethereum |
+| USD Coin | USDC | Polygon PoS |
+| USD Coin | USDC | Solana |
 
 
 <sup>1</sup> [BUSD](/guides/stablecoin/busd) withdrawals are no longer available on the Paxos Platform. [BUSD](/guides/stablecoin/busd) (ERC-20) deposits are supported to redeem for USD or convert to [USDP](/guides/stablecoin/usdp). **Do not deposit BUSD via Binance Smart Chain (BSC)**.
 
 ## Trading and Custody
 
-| Digital Asset                                 | Bitcoin | Bitcoin Cash | Ethereum | Litecoin | Solana |
-|-----------------------------------------------| :---: | :---: | :---: | :---: | :---: |
-| Aave (AAVE)                                   | -- | -- | ✅ | -- | -- |
-| Arbitrum (ARB)                                | -- | -- | ✅ | -- | -- |
-| Bitcoin (BTC)<sup>2</sup>                     | ✅ | -- | -- | -- | -- |
-| Bitcoin Cash (BCH)                            | -- | ✅ | -- | -- | -- |
-| Bonk (BONK)                                   | -- | -- | -- | -- | ✅ |
-| Chainlink (LINK)                              | -- | -- | ✅ | -- | -- |
-| dogwifhat (WIF)                               | -- | -- | -- | -- | ✅ |
-| Ethena (ENA)                                  | -- | -- | ✅ | -- | -- |
-| Ethereum (ETH)                                | -- | -- | ✅ | -- | -- |
-| Litecoin (LTC)                                | -- | -- | -- | ✅ | -- |
-| Mantle (MNT)                                  | -- | -- | ✅ | -- | -- |
-| Official Trump (TRUMP)                        | -- | -- | -- | -- | ✅ |
-| Ondo (ONDO)                                   | -- | -- | ✅ | -- | -- |
-| Pax Gold ([PAXG](https://paxos.com/paxgold/)) | -- | -- | ✅ | -- | -- |
-| Pepe (PEPE)                                   | -- | -- | ✅ | -- | -- |
-| Pudgy Penguins (PENGU)                        | -- | -- | -- | -- | ✅ |
-| Quant (QNT)                                   | -- | -- | ✅ | -- | -- |
-| Render (RENDER)                               | -- | -- | -- | -- | ✅ |
-| Shiba Inu (SHIB)                              | -- | -- | ✅ | -- | -- |
-| Sky (SKY)                                     | -- | -- | ✅ | -- | -- |
-| Solana (SOL)                                  | -- | -- | -- | -- | ✅ |
-| Uniswap (UNI)                                 | -- | -- | ✅ | -- | -- |
-| Worldcoin (WLD)                               | -- | -- | ✅ | -- | -- |
+All digital assets below are available for both trading and custody on the Paxos Platform.
+
+| Asset | Ticker | Network | Token Type |
+| --- | --- | --- | --- |
+| Aave | AAVE | Ethereum | ERC-20 |
+| Arbitrum | ARB | Ethereum | ERC-20 |
+| Bitcoin | BTC<sup>2</sup> | Bitcoin | Native |
+| Bitcoin Cash | BCH | Bitcoin Cash | Native |
+| Bonk | BONK | Solana | SPL |
+| Chainlink | LINK | Ethereum | ERC-20 |
+| Ethena | ENA | Ethereum | ERC-20 |
+| Ethereum | ETH | Ethereum | Native |
+| Litecoin | LTC | Litecoin | Native |
+| Mantle | MNT | Ethereum | ERC-20 |
+| Official Trump | TRUMP | Solana | SPL |
+| Ondo Finance | ONDO | Ethereum | ERC-20 |
+| Pax Gold | PAXG | Ethereum | ERC-20 |
+| Pepe | PEPE | Ethereum | ERC-20 |
+| Pudgy Penguins | PENGU | Solana | SPL |
+| Quant | QNT | Ethereum | ERC-20 |
+| Render | RENDER | Solana | SPL |
+| Shiba Inu | SHIB | Ethereum | ERC-20 |
+| Sky | SKY | Ethereum | ERC-20 |
+| Solana | SOL | Solana | Native |
+| Uniswap | UNI | Ethereum | ERC-20 |
+| Worldcoin | WLD | Ethereum | ERC-20 |
+| dogwifhat | WIF | Solana | SPL |
 
 <sup>2</sup> Supported wallet types for BTC withdrawals: P2WPKH, P2WSH, P2PKH, P2SH, and P2TR (Taproot).
 

--- a/guides/developer/blockchains.mdx
+++ b/guides/developer/blockchains.mdx
@@ -29,18 +29,30 @@ These assets are supported in the context of three main use cases:
 | Digital Asset                                 | Bitcoin | Bitcoin Cash | Ethereum | Litecoin | Solana |
 |-----------------------------------------------| :---: | :---: | :---: | :---: | :---: |
 | Aave (AAVE)                                   | -- | -- | ✅ | -- | -- |
+| Arbitrum (ARB)                                | -- | -- | ✅ | -- | -- |
 | Bitcoin (BTC)<sup>2</sup>                     | ✅ | -- | -- | -- | -- |
 | Bitcoin Cash (BCH)                            | -- | ✅ | -- | -- | -- |
+| Bonk (BONK)                                   | -- | -- | -- | -- | ✅ |
 | Chainlink (LINK)                              | -- | -- | ✅ | -- | -- |
+| dogwifhat (WIF)                               | -- | -- | -- | -- | ✅ |
+| Ethena (ENA)                                  | -- | -- | ✅ | -- | -- |
 | Ethereum (ETH)                                | -- | -- | ✅ | -- | -- |
 | Litecoin (LTC)                                | -- | -- | -- | ✅ | -- |
+| Mantle (MNT)                                  | -- | -- | ✅ | -- | -- |
+| Official Trump (TRUMP)                        | -- | -- | -- | -- | ✅ |
+| Ondo (ONDO)                                   | -- | -- | ✅ | -- | -- |
 | Pax Gold ([PAXG](https://paxos.com/paxgold/)) | -- | -- | ✅ | -- | -- |
-| Solana (SOL)<sup>3</sup>                      | -- | -- | -- | -- | ✅ |
+| Pepe (PEPE)                                   | -- | -- | ✅ | -- | -- |
+| Pudgy Penguins (PENGU)                        | -- | -- | -- | -- | ✅ |
+| Quant (QNT)                                   | -- | -- | ✅ | -- | -- |
+| Render (RENDER)                               | -- | -- | -- | -- | ✅ |
+| Shiba Inu (SHIB)                              | -- | -- | ✅ | -- | -- |
+| Sky (SKY)                                     | -- | -- | ✅ | -- | -- |
+| Solana (SOL)                                  | -- | -- | -- | -- | ✅ |
 | Uniswap (UNI)                                 | -- | -- | ✅ | -- | -- |
+| Worldcoin (WLD)                               | -- | -- | ✅ | -- | -- |
 
 <sup>2</sup> Supported wallet types for BTC withdrawals: P2WPKH, P2WSH, P2PKH, P2SH, and P2TR (Taproot).
-
-<sup>3</sup> Trading or custody of SOL is not available to residents of the US.
 
 ## Blockchain Transactions
 


### PR DESCRIPTION
## What changed
- removed the SOL US-resident availability footnote from the Trading and Custody section
- added the requested trading and custody assets to the blockchain developer guide table
- mapped each new asset to the requested supported network column (ERC-20 -> Ethereum, SPL -> Solana)

## Why
- keep the blockchain developer guide aligned with the current supported Trading and Custody asset list

## Impact
- developers referencing `guides/developer/blockchains.mdx` will see the updated asset coverage and supported network at a glance

## Validation
- reviewed the rendered markdown table structure in `guides/developer/blockchains.mdx`
- no automated tests were run because this is a documentation-only change