### PR TITLE
CHAINS-8692 update LTC required confirmations to 20 in developer docs

### DIFF
--- a/guides/developer/blockchains.mdx
+++ b/guides/developer/blockchains.mdx
@@ -60,7 +60,7 @@ Paxos considers a blockchain transaction (deposit or withdraw) complete once the
 | Bitcoin | 3 | 30 minutes |
 | Bitcoin Cash | 15 | 150 minutes |
 | Ethereum | 12 | 3 minutes |
-| Litecoin | 12 | 30 minutes |
+| Litecoin | 20 | 50 minutes |
 | Polygon PoS | 256 | 9 minutes |
 | Solana | 32 slots | 16 seconds |
 | Stellar | 1 | 5 seconds |


### PR DESCRIPTION
## Summary

Updates the public **Required Confirmations** table on `docs.paxos.com/guides/developer/blockchains` to reflect Litecoin's new deposit-confirmation depth of **20 blocks** (raised from 12) and the corresponding ~50-minute processing time.

## Context

Mitigation from the 2026-04-25 Litecoin reorg incident (FireHydrant `85540033-85c0-4a35-9023-52882fa00fad`, [INC-1120](https://itbitwiki.atlassian.net/browse/INC-1120)). A 13-block LTC reorg exceeded our 12-confirmation threshold; we raised confirmations to 20 across `cryptocoin-service`. The public docs still showed the old value — this PR brings them in line with what the system actually does.

Jira: [CHAINS-8692](https://itbitwiki.atlassian.net/browse/CHAINS-8692)
Retro: [Apr2026 Retro: Incident 1684 Litecoin reorg](https://docs.google.com/document/d/1O0JYx8JBlLn5gqrvFTO-59hMxlLS5BN8lVq_HAparlk/edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[INC-1120]: https://itbitwiki.atlassian.net/browse/INC-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHAINS-8692]: https://itbitwiki.atlassian.net/browse/CHAINS-8692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ